### PR TITLE
Enable setting passcode lock on logout flow

### DIFF
--- a/submodules/TelegramUI/TelegramUI/PasscodeOptionsController.swift
+++ b/submodules/TelegramUI/TelegramUI/PasscodeOptionsController.swift
@@ -214,6 +214,7 @@ func passcodeOptionsController(context: AccountContext) -> ViewController {
     var presentControllerImpl: ((ViewController, ViewControllerPresentationArguments) -> Void)?
     var pushControllerImpl: ((ViewController) -> Void)?
     var popControllerImpl: (() -> Void)?
+    var popBackToControllerImpl: ((Int) -> Void)?
     var replaceTopControllerImpl: ((ViewController, Bool) -> Void)?
 
     let actionsDisposable = DisposableSet()
@@ -293,7 +294,7 @@ func passcodeOptionsController(context: AccountContext) -> ViewController {
             }) |> deliverOnMainQueue).start(next: { _ in
             }, error: { _ in
             }, completed: {
-                popControllerImpl?()
+                popBackToControllerImpl?(2)
             })
         }
         pushControllerImpl?(setupController)
@@ -393,6 +394,12 @@ func passcodeOptionsController(context: AccountContext) -> ViewController {
     }
     pushControllerImpl = { [weak controller] c in
         (controller?.navigationController as? NavigationController)?.pushViewController(c)
+    }
+    popBackToControllerImpl = { [weak controller] i in
+        if let controller = controller, let navigationController = controller.navigationController as? NavigationController, let viewControllers = controller.navigationController?.viewControllers {
+            let index = viewControllers.count - i - 1
+            let _ = navigationController.popToViewController(viewControllers[index], animated: true)
+        }
     }
     popControllerImpl = { [weak controller] in
         let _ = (controller?.navigationController as? NavigationController)?.popViewController(animated: true)


### PR DESCRIPTION
Added Set Passcode On option when passcode is disabled and user would like to enable it from Set Passcode screen within the Log Off's alternatives.

**Not Working flow:**
<img src="https://user-images.githubusercontent.com/25382699/60767441-878b7100-a0b8-11e9-8495-fa33247bf430.gif" width="200" height="430"/>

**Working flow as in the changes of this PR:**
<img src="https://user-images.githubusercontent.com/25382699/60769470-6b93c980-a0d0-11e9-9c37-3cbb409e927f.gif" width="200" height="430"/>
