### PR TITLE
Update for Xcode 11

### DIFF
--- a/submodules/Display/Display/StatusBarProxyNode.swift
+++ b/submodules/Display/Display/StatusBarProxyNode.swift
@@ -16,6 +16,10 @@ public enum StatusBarStyle {
                 self = .White
             case .blackOpaque:
                 self = .Black
+            case .darkContent:
+                self = .Black
+            default:
+                self = .Black
         }
     }
     


### PR DESCRIPTION
Xcode 11 (and iOS 13) has additional `darkContent` case for `UIStatusBarStyle`. In order to prevent further issues, a default case is also added.