### PR TITLE
Fix compatibility issue with input methods when checking availability

### DIFF
--- a/submodules/PeerInfoUI/Sources/ChannelVisibilityController.swift
+++ b/submodules/PeerInfoUI/Sources/ChannelVisibilityController.swift
@@ -868,10 +868,7 @@ public func channelVisibilityController(context: AccountContext, peerId: PeerId,
                 return state.withUpdatedEditingPublicLinkText(text).withUpdatedAddressNameValidationStatus(nil)
             }
         } else if currentText == text {
-            checkAddressNameDisposable.set(nil)
-            updateState { state in
-                return state.withUpdatedEditingPublicLinkText(text).withUpdatedAddressNameValidationStatus(nil).withUpdatedAddressNameValidationStatus(nil)
-            }
+            return
         } else {
             updateState { state in
                 return state.withUpdatedEditingPublicLinkText(text)

--- a/submodules/SettingsUI/Sources/UsernameSetupController.swift
+++ b/submodules/SettingsUI/Sources/UsernameSetupController.swift
@@ -249,10 +249,7 @@ public func usernameSetupController(context: AccountContext) -> ViewController {
                 return state.withUpdatedEditingPublicLinkText(text).withUpdatedAddressNameValidationStatus(nil)
             }
         } else if currentText == text {
-            checkAddressNameDisposable.set(nil)
-            updateState { state in
-                return state.withUpdatedEditingPublicLinkText(text).withUpdatedAddressNameValidationStatus(nil).withUpdatedAddressNameValidationStatus(nil)
-            }
+            return
         } else {
             updateState { state in
                 return state.withUpdatedEditingPublicLinkText(text)


### PR DESCRIPTION
This bug happens when using an input method that uses in-place marked text, Chinese pinyin for example. When the user selects a word, the `.editingChanged` action gets triggered twice simultaneously, which causes the availability checker to stop until the text's changed again, as the video shows below:

![test](https://user-images.githubusercontent.com/6648210/77935435-ff06cd80-72e3-11ea-914c-bcbd521327d0.gif)


