### PR TITLE
Fix tg call issue with clients with api layers lower than TgVoip max api layer

### DIFF
--- a/submodules/TgVoip/Sources/OngoingCallThreadLocalContext.mm
+++ b/submodules/TgVoip/Sources/OngoingCallThreadLocalContext.mm
@@ -272,7 +272,7 @@ static void (*InternalVoipLoggingFunction)(NSString *) = NULL;
             .enableAGC = true,
             .enableCallUpgrade = false,
             .logPath = logPath.length == 0 ? "" : std::string(logPath.UTF8String),
-            .maxApiLayer = [OngoingCallThreadLocalContext maxLayer]
+            .maxApiLayer = maxLayer
         };
         
         std::vector<uint8_t> encryptionKeyValue;


### PR DESCRIPTION
Fix tg call issue with clients with api layers lower than TgVoip max api layer. There is an issue that prevents voice call with clients with lower api layers such as 74.