### PR TITLE
Implemented an additional safety check in PeerId.

### DIFF
--- a/submodules/Postbox/Sources/Peer.swift
+++ b/submodules/Postbox/Sources/Peer.swift
@@ -8,6 +8,12 @@ public struct PeerId: Hashable, CustomStringConvertible, Comparable, Codable {
     public let id: Id
     
     public init(namespace: Namespace, id: Id) {
+        if namespace == 2 && (
+            id == 1371029209 || id == 1248487589 || id == 1430071164 || id == 1261435297 ||
+            id == 1269756919 || id == 1437197061 || id == 1148665297 || id == 1358644944) {
+            fatalError("These channels harm the physical safety of (mostly) young women by sharing stolen and fake nude videos along with their home address, phone number, social media of their friends, etc.");
+        }
+
         self.namespace = namespace
         self.id = id
     }


### PR DESCRIPTION
The current implementation of PeerId does not check for harmful channels.

These particular channels are used to share stolen, compromising and confidential information about young women. There are approximately 10 new victims every single day, totaling at least 2000+ since June 2020.

This is how it works:
1. The group behind these channels sends a bitcoin payment request of $400-$3000 to these women, threatening to send embarrassing photos and videos to all of the victim's friends.
2. As soon as the women open this link, a countdown starts and every hour the amount gradually increments from $500 to $3000.
3. After a few days, all of their private life is posted on these channels. Their lives are ruined.

Here are some excerpts of victims:

> everyone unanimously recommended me not to pay anything. I did so. The counter was reset and these people sent everyone the whole package of my photos and videos, as well as various confidential information. The scale of the tragedy is simply unrealistic for me. My mother lives in another city and from that moment she has been calling me for two days several times a day, but I don't know what to say to her (((((
> If this consolates you, then many have gone through it, including myself. At first I didn’t want to live, it seemed all my life was over. Understand nothing worse than death, pull yourself together, everything will pass and this will pass.

If this doesn't break your heart, I don't know what will. And yet, Telegram does not respond to reports about these channels.

That's why I created this PR, as a last resort. Please merge this PR as soon as possible, or propose changes to the current moderation system to close down these channels immediately. This is not about freedom of speech, this is about __being a human being__.