### PR TITLE
Swap first name and last name if name is Korean language

### DIFF
--- a/submodules/LegacyComponents/PublicHeaders/LegacyComponents/TGStringUtils.h
+++ b/submodules/LegacyComponents/PublicHeaders/LegacyComponents/TGStringUtils.h
@@ -12,6 +12,7 @@ int32_t phoneMatchHash(NSString *phone);
 bool TGIsRTL();
 bool TGIsArabic();
 bool TGIsKorean();
+bool TGIsKoreanName(NSString *firstName, NSString *lastName);
 bool TGIsLocaleArabic();
     
 #ifdef __cplusplus

--- a/submodules/LegacyComponents/Sources/TGStringUtils.mm
+++ b/submodules/LegacyComponents/Sources/TGStringUtils.mm
@@ -1191,6 +1191,22 @@ bool TGIsKorean()
     return value;
 }
 
+static NSPredicate *koreanPredicate = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"^[ㄱ-ㅎㅏ-ㅣ가-힣]{2,8}"];
+bool TGIsKoreanName(NSString *firstName, NSString *lastName)
+{
+    static bool value = false;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^
+    {
+        if (firstName.length < 4 || lastName.length < 4) {
+            value = [koreanPredicate evaluateWithObject:[NSString stringWithFormat:@"%@%@", lastName, firstName]];
+        } else {
+            value = false;
+        }
+    });
+    return value;
+}
+
 bool TGIsLocaleArabic()
 {
     static bool value = false;

--- a/submodules/LegacyComponents/Sources/TGUser.m
+++ b/submodules/LegacyComponents/Sources/TGUser.m
@@ -159,7 +159,7 @@ typedef enum {
     
     if (firstName != nil && firstName.length != 0 && lastName != nil && lastName.length != 0)
     {
-        if (TGIsKorean())
+        if (TGIsKorean() || TGIsKoreanName(firstName, lastName))
             return [[NSString alloc] initWithFormat:@"%@ %@", lastName, firstName];
         else
             return [[NSString alloc] initWithFormat:@"%@ %@", firstName, lastName];


### PR DESCRIPTION
This commit displays last name first if name is Korean language and is reasonable Korean name format.
For some reason, I use my device in English language with UK region but it always shows name in first name first. This was quite inconvenient for me since lots of my friends are Korean. I hope this solves the inconvenience.