### PR TITLE
[iOS 15] System-wide translation support

### DIFF
--- a/submodules/TextSelectionNode/Sources/TextSelectionNode.swift
+++ b/submodules/TextSelectionNode/Sources/TextSelectionNode.swift
@@ -188,6 +188,7 @@ public enum TextSelectionAction {
     case share
     case lookup
     case speak
+    case translate
 }
 
 public final class TextSelectionNode: ASDisplayNode {
@@ -479,6 +480,13 @@ public final class TextSelectionNode: ASDisplayNode {
         self.updateSelection(range: nil, animateIn: false)
     }
     
+    private func isTranslateSelectionAvailable() -> Bool {
+        if #available(iOS 15, *) {
+            return true
+        }
+        return false
+    }
+    
     private func displayMenu() {
         guard let currentRects = self.currentRects, !currentRects.isEmpty, let currentRange = self.currentRange, let cachedLayout = self.textNode.cachedLayout, let attributedString = cachedLayout.attributedString else {
             return
@@ -501,12 +509,21 @@ public final class TextSelectionNode: ASDisplayNode {
             self?.performAction(attributedText, .lookup)
             self?.dismissSelection()
         }))
+        
         if isSpeakSelectionEnabled() {
             actions.append(ContextMenuAction(content: .text(title: self.strings.Conversation_ContextMenuSpeak, accessibilityLabel: self.strings.Conversation_ContextMenuSpeak), action: { [weak self] in
                 self?.performAction(attributedText, .speak)
                 self?.dismissSelection()
             }))
         }
+        
+        if isTranslateSelectionAvailable() {
+            actions.append(ContextMenuAction(content: .text(title: self.strings.Conversation_ContextMenuTranslate, accessibilityLabel: self.strings.Conversation_ContextMenuTranslate), action: { [weak self] in
+                self?.performAction(attributedText, .translate)
+                self?.dismissSelection()
+            }))
+        }
+        
         actions.append(ContextMenuAction(content: .text(title: self.strings.Conversation_ContextMenuShare, accessibilityLabel: self.strings.Conversation_ContextMenuShare), action: { [weak self] in
             self?.performAction(attributedText, .share)
             self?.dismissSelection()


### PR DESCRIPTION
https://bugs.telegram.org/c/9297

PS: where are the menu item strings as `Conversation_ContextMenuShare` defined? Did not find them with the search. Seems they do they come with the TG localization and not iOS. The `Conversation_ContextMenuTranslate` needs to be added there. Thanks.