### PR TITLE
Fix bazel download link for intel-based machine

### DIFF
--- a/build-system/Make/BazelLocation.py
+++ b/build-system/Make/BazelLocation.py
@@ -9,7 +9,7 @@ def locate_bazel(base_path):
     if is_apple_silicon():
         arch = 'darwin-arm64'
     else:
-        arch = 'x86_64'
+        arch = 'darwin-x86_64'
     bazel_name = 'bazel-{version}-{arch}'.format(version=versions.bazel_version, arch=arch)
     bazel_path = '{}/build-input/{}'.format(base_path, bazel_name)
 


### PR DESCRIPTION
Download link for intel-based x86_64:
https://github.com/bazelbuild/bazel/releases/download/5.0.0/bazel-5.0.0-darwin-x86_64