### PR TITLE
Fix respecting reduce motion when reacting to messages

### DIFF
--- a/submodules/ReactionSelectionNode/Sources/ReactionContextNode.swift
+++ b/submodules/ReactionSelectionNode/Sources/ReactionContextNode.swift
@@ -585,20 +585,23 @@ public final class ReactionContextNode: ASDisplayNode, UIScrollViewDelegate {
         
         let additionalAnimationNode = AnimatedStickerNode()
         
-        let additionalAnimation: TelegramMediaFile
-        if self.didTriggerExpandedReaction {
-            additionalAnimation = itemNode.item.largeApplicationAnimation
-            if incomingMessage {
-                additionalAnimationNode.transform = CATransform3DMakeScale(-1.0, 1.0, 1.0)
+        let reduceMotion = self.context.sharedContext.currentPresentationData.with({ $0 }).reduceMotion
+        if !reduceMotion {
+            let additionalAnimation: TelegramMediaFile
+            if self.didTriggerExpandedReaction {
+                additionalAnimation = itemNode.item.largeApplicationAnimation
+                if incomingMessage {
+                    additionalAnimationNode.transform = CATransform3DMakeScale(-1.0, 1.0, 1.0)
+                }
+            } else {
+                additionalAnimation = itemNode.item.applicationAnimation
             }
-        } else {
-            additionalAnimation = itemNode.item.applicationAnimation
+            
+            additionalAnimationNode.setup(source: AnimatedStickerResourceSource(account: itemNode.context.account, resource: additionalAnimation.resource), width: Int(effectFrame.width * 2.0), height: Int(effectFrame.height * 2.0), playbackMode: .once, mode: .direct(cachePathPrefix: itemNode.context.account.postbox.mediaBox.shortLivedResourceCachePathPrefix(additionalAnimation.resource.id)))
+            additionalAnimationNode.frame = effectFrame
+            additionalAnimationNode.updateLayout(size: effectFrame.size)
+            self.addSubnode(additionalAnimationNode)
         }
-        
-        additionalAnimationNode.setup(source: AnimatedStickerResourceSource(account: itemNode.context.account, resource: additionalAnimation.resource), width: Int(effectFrame.width * 2.0), height: Int(effectFrame.height * 2.0), playbackMode: .once, mode: .direct(cachePathPrefix: itemNode.context.account.postbox.mediaBox.shortLivedResourceCachePathPrefix(additionalAnimation.resource.id)))
-        additionalAnimationNode.frame = effectFrame
-        additionalAnimationNode.updateLayout(size: effectFrame.size)
-        self.addSubnode(additionalAnimationNode)
         
         var mainAnimationCompleted = false
         var additionalAnimationCompleted = false


### PR DESCRIPTION
Currently reduce motion setting is not being respected by the message reactions
In this iteration I propose to not play auxiliary animation making the overall reaction involve less motion (please see attached videos, they play inline on macOS or following the links on windows)

See attached videos:

| With reduce motion disabled | With reduce motion enabled |
| --- | --- |
<video src="https://user-images.githubusercontent.com/2688806/156899326-88f81d38-4aca-49c2-a7a5-e1801052c902.mp4" width="30%"> | <video src="https://user-images.githubusercontent.com/2688806/156899358-eb470dd5-ea11-4c87-9f52-91d22f82f163.mp4" width="30%">
