### PR TITLE
Fix incorrect proxy request address type for IPv6

### DIFF
--- a/submodules/MtProtoKit/Sources/MTTcpConnection.m
+++ b/submodules/MtProtoKit/Sources/MTTcpConnection.m
@@ -1315,11 +1315,22 @@ struct ctr_state {
     req.Version = 5;
     req.Cmd = 1;
     req.Reserved = 0;
-    req.AddrType = 1;
     
     struct in_addr ip4;
-    inet_aton(_scheme.address.ip.UTF8String, &ip4);
-    req.DestAddr.IPv4 = ip4;
+    struct in6_addr ip6;
+
+    if (inet_aton(_scheme.address.ip.UTF8String, &ip4) == 1) {
+        req.DestAddr.IPv4 = ip4;
+        req.AddrType = 1;
+    } else if (inet_pton(AF_INET6, _scheme.address.ip.UTF8String, &ip6) == 1) {
+        req.DestAddr.IPv6 = ip6;
+        req.AddrType = 4;
+    } else {
+        [_scheme.address.ip getCString:req.DestAddr.Domain maxLength:sizeof(req.DestAddr.Domain) encoding:NSASCIIStringEncoding];
+        req.DestAddr.DomainLen = _scheme.address.ip.length;
+        req.AddrType = 3;
+    }
+    
     req.DestPort = _scheme.address.port;
     
     NSMutableData *reqData = [[NSMutableData alloc] init];


### PR DESCRIPTION
I discovered years ago that both the iOS and Mac versions of Telegram send requests to the proxy server for invalid IP , and I created this issue in the TelegramSwift repo about two years ago but got no response. https://github.com/overtake/TelegramSwift/issues/427

So I decided to look into it myself, and I found that MtProtoKit doesn't handle IPv6 addresses correctly at all, so when the upper-level code tries to connect to an IPv6 address via a proxy, it sends a request to an invalid IPv4 address.

This issue has been bugging me for years. Please merge this PR or fix the issue in some other way as soon as possible, thanks.

