### PR TITLE
Fix contact saved handle format

### DIFF
--- a/submodules/AccountContext/Sources/DeviceContactData.swift
+++ b/submodules/AccountContext/Sources/DeviceContactData.swift
@@ -187,11 +187,11 @@ public final class DeviceContactInstantMessagingProfileData: Equatable, Hashable
 }
 
 public let phonebookUsernamePathPrefix = "@id"
-private let phonebookUsernamePrefix = "https://t.me/" + phonebookUsernamePathPrefix
+private let phonebookUsernamePrefix = "https://t.me/"
 
 public extension DeviceContactUrlData {
-    convenience init(appProfile: PeerId) {
-        self.init(label: "Telegram", value: "\(phonebookUsernamePrefix)\(appProfile.id)")
+    convenience init(addressName: String) {
+        self.init(label: "Telegram", value: "\(phonebookUsernamePrefix)\(addressName)")
     }
 }
 

--- a/submodules/PeerInfoUI/Sources/DeviceContactInfoController.swift
+++ b/submodules/PeerInfoUI/Sources/DeviceContactInfoController.swift
@@ -1072,7 +1072,8 @@ public func deviceContactInfoController(context: AccountContext, updatedPresenta
             if let editingName = state.editingState?.editingName, case let .personName(firstName, lastName, _) = editingName, (!firstName.isEmpty || !lastName.isEmpty) {
                 var urls = filteredData.urls
                 if let createForPeer = createForPeer {
-                    let appProfile = DeviceContactUrlData(appProfile: createForPeer.id)
+                    let addressName: String = createForPeer.addressName ?? ""
+                    let appProfile = DeviceContactUrlData(addressName: addressName)
                     var found = false
                     for url in urls {
                         if url.label == appProfile.label && url.value == appProfile.value {


### PR DESCRIPTION
Resolves: https://github.com/TelegramMessenger/Telegram-iOS/issues/685
Contact saved with usernames as https://t.me/@idId(rawValue:%xxx

After change:
<img src="https://user-images.githubusercontent.com/29634986/159571254-367ef536-c4df-48e0-9a29-6cff241dc5bd.png" height=350>
