### PR TITLE
Fix typos for ApplockState

### DIFF
--- a/submodules/AppLock/Sources/AppLock.swift
+++ b/submodules/AppLock/Sources/AppLock.swift
@@ -308,8 +308,8 @@ public final class AppLockContextImpl: AppLockContext {
     public var invalidAttempts: Signal<AccessChallengeAttempts?, NoError> {
         return self.currentState.get()
         |> map { state in
-            return state.unlockAttemts.flatMap { unlockAttemts in
-                return AccessChallengeAttempts(count: unlockAttemts.count, bootTimestamp: unlockAttemts.timestamp.bootTimestamp, uptime: unlockAttemts.timestamp.uptime)
+            return state.unlockAttempts.flatMap { unlockAttempts in
+                return AccessChallengeAttempts(count: unlockAttempts.count, bootTimestamp: unlockAttempts.timestamp.bootTimestamp, uptime: unlockAttempts.timestamp.uptime)
             }
         }
     }
@@ -338,7 +338,7 @@ public final class AppLockContextImpl: AppLockContext {
         self.updateLockState { state in
             var state = state
             
-            state.unlockAttemts = nil
+            state.unlockAttempts = nil
             
             state.isManuallyLocked = false
             
@@ -354,16 +354,16 @@ public final class AppLockContextImpl: AppLockContext {
     public func failedUnlockAttempt() {
         self.updateLockState { state in
             var state = state
-            var unlockAttemts = state.unlockAttemts ?? UnlockAttempts(count: 0, timestamp: MonotonicTimestamp(bootTimestamp: 0, uptime: 0))
+            var unlockAttempts = state.unlockAttempts ?? UnlockAttempts(count: 0, timestamp: MonotonicTimestamp(bootTimestamp: 0, uptime: 0))
             
-            unlockAttemts.count += 1
+            unlockAttempts.count += 1
             
             var bootTimestamp: Int32 = 0
             let uptime = getDeviceUptimeSeconds(&bootTimestamp)
             let timestamp = MonotonicTimestamp(bootTimestamp: bootTimestamp, uptime: uptime)
             
-            unlockAttemts.timestamp = timestamp
-            state.unlockAttemts = unlockAttemts
+            unlockAttempts.timestamp = timestamp
+            state.unlockAttempts = unlockAttempts
             return state
         }
     }

--- a/submodules/AppLockState/Sources/AppLockState.swift
+++ b/submodules/AppLockState/Sources/AppLockState.swift
@@ -24,13 +24,13 @@ public struct UnlockAttempts: Codable, Equatable {
 public struct LockState: Codable, Equatable {
     public var isManuallyLocked: Bool
     public var autolockTimeout: Int32?
-    public var unlockAttemts: UnlockAttempts?
+    public var unlockAttempts: UnlockAttempts?
     public var applicationActivityTimestamp: MonotonicTimestamp?
 
-    public init(isManuallyLocked: Bool = false, autolockTimeout: Int32? = nil, unlockAttemts: UnlockAttempts? = nil, applicationActivityTimestamp: MonotonicTimestamp? = nil) {
+    public init(isManuallyLocked: Bool = false, autolockTimeout: Int32? = nil, unlockAttempts: UnlockAttempts? = nil, applicationActivityTimestamp: MonotonicTimestamp? = nil) {
         self.isManuallyLocked = isManuallyLocked
         self.autolockTimeout = autolockTimeout
-        self.unlockAttemts = unlockAttemts
+        self.unlockAttempts = unlockAttempts
         self.applicationActivityTimestamp = applicationActivityTimestamp
     }
 }


### PR DESCRIPTION
Fix typos for ApplockState: `unlockAttemts` -> `unlockAttempts`