### PR TITLE
Correction of error messages when 4 chars or sold

### DIFF
--- a/submodules/TelegramCore/Sources/TelegramEngine/Peers/AddressNames.swift
+++ b/submodules/TelegramCore/Sources/TelegramEngine/Peers/AddressNames.swift
@@ -34,7 +34,7 @@ func _internal_checkAddressNameFormat(_ value: String, canEmpty: Bool = false) -
             if index == 0 {
                 return .startsWithUnderscore
             } else if index == length - 1 {
-                return length < 4 ? .tooShort : .endsWithUnderscore
+                return length <= 4 ? .tooShort : .endsWithUnderscore
             }
         }
         if index == 0 && char >= "0" && char <= "9" {
@@ -46,7 +46,7 @@ func _internal_checkAddressNameFormat(_ value: String, canEmpty: Bool = false) -
         index += 1
     }
     
-    if length < 4 && (!canEmpty || length != 0) {
+    if length <= 4 && (!canEmpty || length != 0) {
         return .tooShort
     }
     return nil
@@ -87,7 +87,7 @@ func _internal_addressNameAvailability(account: Account, domain: AddressNameDoma
                         if error.errorDescription == "USERNAME_PURCHASE_AVAILABLE" {
                             return .single(.purchaseAvailable)
                         } else {
-                            return .single(.invalid)
+                            return .single(.taken)
                         }
                     }
                 } else if peerId.namespace == Namespaces.Peer.CloudGroup {


### PR DESCRIPTION
## Related Issues
In this version I am trying to correct the issues mentioned on issues #870 and #1002.

## Difference
When a username has exact 4 characters the message shown to the user is that "Username must have at least 5 characters" instead of the "Username is taken" that actually appears and when a username has been already sold in fragment.com the error message that appears to the user is "Username is taken" instead of the error message that is currently shown which is "Only a-z, 0-9, and underscore allowed" and could create misunderstandings. 

## Screenshots and Videos
Below you can see how it works in the app right now compared to how it works after these minor changes.


https://user-images.githubusercontent.com/74301392/218283940-e5425530-6395-4f19-96aa-2eeefaa15502.mp4


https://user-images.githubusercontent.com/74301392/218283961-a3df6fcc-dd02-48bc-979d-747201b8d134.mp4


https://user-images.githubusercontent.com/74301392/218283946-56d3229e-bab6-4769-88be-f8803cf3ba28.mp4


https://user-images.githubusercontent.com/74301392/218283947-92cf53f1-35f2-4cfd-9a0c-a844fcdd859f.mp4



