### PR TITLE
Open location in Yandex Go

### DIFF
--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -1782,6 +1782,7 @@ plist_fragment(
         <string>foursquare</string>
         <string>here-location</string>
         <string>yandexmaps</string>
+        <string>yandextaxi</string>
         <string>yandexnavi</string>
         <string>comgooglemaps</string>
         <string>youtube</string>

--- a/submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift
+++ b/submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift
@@ -323,6 +323,10 @@ private func allOpenInOptions(context: AccountContext, item: OpenInItem) -> [Ope
                     return .openUrl(url: url)
                 }
             }))
+            
+            options.append(OpenInOption(identifier: "yandexGo", application: .other(title: "Yangex Go", identifier: 472650686, scheme: "yandextaxi", store: nil), action: {
+                return .openUrl(url: "yandextaxi://route?end-lat=\(lat)&end-lon=\(lon)")
+            }))
     }
     return options
 }


### PR DESCRIPTION
Added the ability to open a location in the Yandex Go app similar to the already implemented for Yandex Maps, 2gis, uber and others