### PR TITLE
Update .gitmodules to support building using --recursive on a fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 
 [submodule "submodules/rlottie/rlottie"]
 	path = submodules/rlottie/rlottie
-	url=TelegramMessenger/rlottie.git
+	url=https://github.com/TelegramMessenger/rlottie.git
 [submodule "build-system/bazel-rules/rules_apple"]
 	path = build-system/bazel-rules/rules_apple
 	url=https://github.com/ali-fareed/rules_apple.git
@@ -19,7 +19,7 @@
 	url=https://github.com/bazelbuild/tulsi.git
 [submodule "submodules/TgVoipWebrtc/tgcalls"]
 	path = submodules/TgVoipWebrtc/tgcalls
-	url=TelegramMessenger/tgcalls.git
+	url=https://github.com/TelegramMessenger/tgcalls.git
 [submodule "third-party/libvpx/libvpx"]
 	path = third-party/libvpx/libvpx
 	url = https://github.com/webmproject/libvpx.git


### PR DESCRIPTION
Currently .gitmodules references the TelegramMessenger github account to pull down `tgcalls` and `rlottie`. These references fail upon forking as the `../` will reference your own personal github account.

I updated the URLs to point directly at TelegramMessenger's repos.