### PR TITLE
Fix: Sending custom emojis adds underlying emojis to recently used

### DIFF
--- a/submodules/TelegramCore/Sources/PendingMessages/EnqueueMessage.swift
+++ b/submodules/TelegramCore/Sources/PendingMessages/EnqueueMessage.swift
@@ -513,11 +513,11 @@ func enqueueMessages(transaction: Transaction, account: Account, peerId: PeerId,
                         transaction.storeMediaIfNotPresent(media: file)
                     }
                 
-                    for emoji in text.emojis {
-                        if emoji.isSingleEmoji {
-                            if !emojiItems.contains(where: { $0.content == .text(emoji) }) {
-                                emojiItems.append(RecentEmojiItem(.text(emoji)))
-                            }
+                    
+                    var filteredEmojiItems = [NSRange: RecentEmojiItem]()
+                    text.enumerateSubstrings(in: text.startIndex ..< text.endIndex, options: .byComposedCharacterSequences) { substring, range, _, _ in
+                        if let substring, substring.isSingleEmoji {
+                            filteredEmojiItems[NSRange(range, in: text)] = RecentEmojiItem(.text(substring))
                         }
                     }
                 
@@ -643,9 +643,15 @@ func enqueueMessages(transaction: Transaction, account: Account, peerId: PeerId,
                                     }
                                 } else if case let .CustomEmoji(_, fileId) = entity.type {
                                     let mediaId = MediaId(namespace: Namespaces.Media.CloudFile, id: fileId)
-                                    if let file = inlineStickers[mediaId] as? TelegramMediaFile {
-                                        emojiItems.append(RecentEmojiItem(.file(file)))
-                                    } else if let file = transaction.getMedia(mediaId) as? TelegramMediaFile {
+                                    let entityRange = NSRange(location: entity.range.lowerBound, length: entity.range.upperBound - entity.range.lowerBound)
+                                    var file: TelegramMediaFile?
+                                    if let unwrappedFile = inlineStickers[mediaId] as? TelegramMediaFile {
+                                        file = unwrappedFile
+                                    } else if let unwrappedFile = transaction.getMedia(mediaId) as? TelegramMediaFile {
+                                        file = unwrappedFile
+                                    }
+                                    if let file {
+                                        filteredEmojiItems.removeValue(forKey: entityRange)
                                         emojiItems.append(RecentEmojiItem(.file(file)))
                                     }
                                 }
@@ -653,6 +659,7 @@ func enqueueMessages(transaction: Transaction, account: Account, peerId: PeerId,
                             break
                         }
                     }
+                    emojiItems.insert(contentsOf: filteredEmojiItems.values, at: 0)
                                     
                     let (tags, globalTags) = tagsForStoreMessage(incoming: false, attributes: attributes, media: mediaList, textEntities: entitiesAttribute?.entities, isPinned: false)
                     


### PR DESCRIPTION
**Description:**
When sending Custom Emojis, their underlaying plain emojis get added to Recently Used.
As far as I can tell from git blame, the bug is in the code for 9 months, before that plain emojis weren't added to recently used at all.

Bug in action:

https://github.com/TelegramMessenger/Telegram-iOS/assets/62802017/dafc1fe4-fa50-43de-b698-ac08d215e744

Fixed:

https://github.com/TelegramMessenger/Telegram-iOS/assets/62802017/b8be8f40-65f6-4e94-b266-8a5b172af0a0

**Steps to reproduce:**
- Premium
- Add any custom emoji pack
- Send a message with custom emojis in it
- Check Recently Used group

_Expected:_ Only Custom Emojis get added to the Recently Used group
_Reality:_ **Both** the custom emoji and plain underlaying emoji get added