### PR TITLE
Fix conflicting check for Archive Chat context item

### DIFF
--- a/submodules/ChatListUI/Sources/ChatContextMenus.swift
+++ b/submodules/ChatListUI/Sources/ChatContextMenus.swift
@@ -350,7 +350,7 @@ func chatContextMenuItems(context: AccountContext, peerId: PeerId, promoInfo: Ch
                         })))
                     }
 
-                    let archiveEnabled = !isSavedMessages && peerId != PeerId(namespace: Namespaces.Peer.CloudUser, id: PeerId.Id._internalFromInt64Value(777000)) && peerId == context.account.peerId
+                    let archiveEnabled = !isSavedMessages && peerId != PeerId(namespace: Namespaces.Peer.CloudUser, id: PeerId.Id._internalFromInt64Value(777000))
                     if let group = peerGroup {
                         if archiveEnabled {
                             let isArchived = group == .archive


### PR DESCRIPTION
`!isSavedMessages` defined as `let isSavedMessages = peerId == context.account.peerId` conflicts with `peerId == context.account.peerId`, meaning the app will never show the "Archive"/"Unarchive" button when long-tapping any chat in the chat list.