### PR TITLE
Fix ripple effect wave animation

### DIFF
--- a/submodules/TelegramUI/Components/SpaceWarpView/Sources/SpaceWarpView.swift
+++ b/submodules/TelegramUI/Components/SpaceWarpView/Sources/SpaceWarpView.swift
@@ -402,7 +402,9 @@ open class SpaceWarpNodeImpl: ASDisplayNode, SpaceWarpNode {
     private var link: SharedDisplayLinkDriver.Link?
     
     private var shockwaves: [Shockwave] = []
-    
+
+    private var hasCompletedFirstInARowShockwave: Bool = false
+
     private var resolution: (x: Int, y: Int)?
     private var layoutParams: (size: CGSize, cornerRadius: CGFloat)?
     
@@ -446,7 +448,11 @@ open class SpaceWarpNodeImpl: ASDisplayNode, SpaceWarpNode {
         if !SpaceWarpNodeImpl.supportsHierarchy(layer: self.contentNodeSource.view.layer) {
             return
         }
-        
+
+        if self.shockwaves.isEmpty {
+            self.hasCompletedFirstInARowShockwave = false
+        }
+
         self.shockwaves.append(Shockwave(startPoint: point))
         if self.shockwaves.count > 8 {
             self.shockwaves.removeFirst()
@@ -516,6 +522,10 @@ open class SpaceWarpNodeImpl: ASDisplayNode, SpaceWarpNode {
         for i in (0 ..< self.shockwaves.count).reversed() {
             if self.shockwaves[i].timeValue >= maxDelay {
                 self.shockwaves.remove(at: i)
+
+                if i == 0 {
+                    self.hasCompletedFirstInARowShockwave = true
+                }
             }
         }
         


### PR DESCRIPTION
If you try using new ripple effect animations in a row several times, the animation will show shockwave's (except the first one) in the last position before removing them from screen which leads to UI bug