### PR TITLE
Use a proper script to call an event in Mini Apps

### DIFF
--- a/submodules/WebUI/Sources/WebAppWebView.swift
+++ b/submodules/WebUI/Sources/WebAppWebView.swift
@@ -227,7 +227,7 @@ final class WebAppWebView: WKWebView {
     }
     
     func sendEvent(name: String, data: String?) {
-        let script = "window.TelegramGameProxy.receiveEvent(\"\(name)\", \(data ?? "null"))"
+        let script = "window.TelegramGameProxy && window.TelegramGameProxy.receiveEvent && window.TelegramGameProxy.receiveEvent(\"\(name)\", \(data ?? "null"))"
         self.evaluateJavaScript(script, completionHandler: { _, _ in
         })
     }


### PR DESCRIPTION
At the moment, developers have problem calling `window.TelegramGameProxy.receiveEvent` even when it is undefined. A possible reason is that the client relies on the `telegram-web-app.js` file inserted in the `head` tag of the web application. This file defines required field in-place, but still, we have a lot of developers not using this approach and using the async one.

To solve the problem, I offer to check if the path `window.TelegramGameProxy.receiveEvent` exists at all, and call the function only if it does.

You can learn more about the issues here:
https://github.com/Telegram-Mini-Apps/telegram-apps/issues/664