### PR TITLE
(Fix #1543) Fixed the bug where tapping the send button while inline text prediction has uncommitted text messes up the message

### DIFF
--- a/submodules/TelegramUI/Sources/ChatTextInputPanelNode.swift
+++ b/submodules/TelegramUI/Sources/ChatTextInputPanelNode.swift
@@ -4506,7 +4506,15 @@ class ChatTextInputPanelNode: ChatInputPanelNode, ASEditableTextNodeDelegate, Ch
     }
     
     @objc func sendButtonPressed() {
-        if let textInputNode = self.textInputNode, let presentationInterfaceState = self.presentationInterfaceState, let editMessage = presentationInterfaceState.interfaceState.editMessage, let inputTextMaxLength = editMessage.inputTextMaxLength {
+        if let textInputNode = self.textInputNode, let textRange = textInputNode.textView.markedTextRange {
+            textInputNode.textView.replace(textRange, withText: "")
+        }
+
+        if let textInputNode = self.textInputNode,
+           let presentationInterfaceState = self.presentationInterfaceState,
+           let editMessage = presentationInterfaceState.interfaceState.editMessage,
+           let inputTextMaxLength = editMessage.inputTextMaxLength {
+
             let textCount = Int32(textInputNode.textView.text.count)
             let remainingCount = inputTextMaxLength - textCount
 


### PR DESCRIPTION
As the title says, this bug has existed since Apple launched the inline text prediction and as a long term Telegram user, it used to drive me insane and even forced me to switch to a different app. Finally got some time to fix this issue and will probably shift back to Telegram.

Before|After
--|--
<video width="300" src="https://github.com/user-attachments/assets/6cfc8262-2de7-4c39-9cc9-d7b4a9d79b1b">|<video width="300" src="https://github.com/user-attachments/assets/01107c1c-d632-467c-b0b6-24682f970ca4">

Note: While this fixes the bug for the text field in the chat, it does not fix the same problem in the caption text field when an attachment is added. That legacy code is completely in obj-c and I don't really understand it much.