### PR TITLE
 Bugfix: Fix UnboundLocalError caused by variable/function name conflict introduced in commit 504cb1d

### DIFF
--- a/build-system/Make/BazelLocation.py
+++ b/build-system/Make/BazelLocation.py
@@ -91,8 +91,8 @@ def locate_bazel(base_path, cache_host_or_path, cache_dir):
                 if test_sha256 == versions.bazel_version_sha256:
                     shutil.copyfile(temp_output_file.name, bazel_path)
         elif resolved_cache_path is not None:
-            (cache_cas_id, cache_cas_name) = cache_cas_name(versions.bazel_version_sha256)
-            cached_path = '{}/cas/{}/{}'.format(resolved_cache_path, cache_cas_id, cache_cas_name)
+            (cache_cas_id, cache_cas_digest_name) = cache_cas_name(versions.bazel_version_sha256)
+            cached_path = '{}/cas/{}/{}'.format(resolved_cache_path, cache_cas_id, cache_cas_digest_name)
             if os.path.isfile(cached_path):
                 shutil.copyfile(cached_path, bazel_path)
 
@@ -137,8 +137,8 @@ def locate_bazel(base_path, cache_host_or_path, cache_dir):
                 )
             ], check_result=False)
         elif resolved_cache_path is not None:
-            (cache_cas_id, cache_cas_name) = cache_cas_name(versions.bazel_version_sha256)
-            cached_path = '{}/cas/{}/{}'.format(resolved_cache_path, cache_cas_id, cache_cas_name)
+            (cache_cas_id, cache_cas_digest_name) = cache_cas_name(versions.bazel_version_sha256)
+            cached_path = '{}/cas/{}/{}'.format(resolved_cache_path, cache_cas_id, cache_cas_digest_name)
             os.makedirs(os.path.dirname(cached_path), exist_ok=True)
             shutil.copyfile(bazel_path, cached_path)
 


### PR DESCRIPTION
### 🐞 Bugfix: Fix `UnboundLocalError` caused by variable/function name conflict introduced in commit `504cb1d`

#### 📍 Problem
Running the project generation script failed with:

```
UnboundLocalError: local variable 'cache_cas_name' referenced before assignment
```

This occurred in `build-system/Make/BazelLocation.py`, in the `locate_bazel` function, due to the following line:

```python
(cache_cas_id, cache_cas_name) = cache_cas_name(versions.bazel_version_sha256)
```

#### ⚠️ Root Cause
This line causes a name conflict between:

- the function `cache_cas_name(...)`, defined earlier in the file
- and the local variable `cache_cas_name`, being declared in the same expression

In Python, assigning a value to a variable shadows the function name within the same scope. Attempting to call it before assignment results in `UnboundLocalError`.

The same issue occurred **twice** in the file:
- First when reading from the local cache
- Second when writing to the cache

#### 💥 When It Broke
The bug was introduced in commit [`504cb1d`](https://github.com/TelegramMessenger/Telegram-iOS/commit/504cb1d), which added logic for using a local CAS cache directory and introduced the line with the shadowed name.

#### ✅ Fix
Renamed the result variable to avoid shadowing the function:

```python
(cache_cas_id, cache_cas_digest_name) = cache_cas_name(...)
```

This change was applied in both occurrences.

#### 📂 Affected File
- `build-system/Make/BazelLocation.py`

#### 🧪 How to Reproduce (before fix)
Run:
```bash
python3 build-system/Make/Make.py \
    --cacheDir="$HOME/telegram-bazel-cache" \
    generateProject \
    --configurationPath=build-system/template_minimal_development_configuration.json \
    --xcodeManagedCodesigning
```

You’ll see the `UnboundLocalError`.

#### 🧯 Result
After the fix, the script works as expected.