### PR TITLE
Add FAQ entry for SwiftSignalKit compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ ERROR: Skipping '@rules_xcodeproj_generated//generator/Telegram/Telegram_xcodepr
 
 If you encounter this issue, re-run the project generation steps in the README.
 
+## Compilation fails with "error: Failed to build module 'SwiftSignalKit'"
+
+If you encounter a build failure related to SwiftSignalKit, try cleaning the build folder and rebuilding:
+```
+# In Xcode, go to Product > Clean Build Folder (Shift+Command+K)
+# Then rebuild the project
+```
 
 # Tips
 


### PR DESCRIPTION
## Description

This PR adds a new FAQ entry to the README addressing a common compilation error related to the SwiftSignalKit module. It provides a straightforward solution for developers who encounter this issue.

## Changes made

- Added a new FAQ entry titled "Compilation fails with 'error: Failed to build module 'SwiftSignalKit'"
- Provided instructions on how to resolve the issue by cleaning the build folder and rebuilding the project
- Included the relevant Xcode shortcut (Shift+Command+K) for convenience

## Motivation

This change helps developers who are new to the Telegram iOS codebase overcome a compilation error that is not currently documented but appears to happen frequently during initial setup attempts.

## Testing

The update was validated by comparing with similar FAQ entries in the README and ensuring consistent formatting.