### PR TITLE
Add FAQ entry for XCode build issues on MacOS 15.4+ (SwiftSignalKitFramework, MtProtoKitFramework, PostboxFramework, TelegramCoreFramework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ ERROR: Skipping '@rules_xcodeproj_generated//generator/Telegram/Telegram_xcodepr
 
 If you encounter this issue, re-run the project generation steps in the README.
 
+## Frameworks issues on MacOS 15.5+: permission denied, no such directory or file
+
+On MacOS 15.5 and newer you might encounter a Xcode build failure accompainded by this errors:
+
+```
+.../SSignalKit/SwiftSignalKit/SwiftSignalKitFramework.framework/Modules/SwiftSignalKit.swiftmodule/arm64-apple-ios.swiftdoc: No such file or directory
+.../MtProtoKit/MtProtoKitFramework.framework/Info.plist': Permission denied (13)
+```
+
+If you encounter this issue, install rsync with following command:
+```
+brew install rsync
+```
+
+After installing rsync, clear build folder and rebuild the project.
 
 # Tips
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you encounter this issue, re-run the project generation steps in the README.
 
 ## XCode build issues with frameworks: permission denied, no such directory or file
 
-On MacOS 15.5 and newer you might encounter a Xcode build failure accompainded by this errors:
+On MacOS 15.4 and newer you might encounter a Xcode build failure accompainded by this errors:
 
 ```
 .../SSignalKit/SwiftSignalKit/SwiftSignalKitFramework.framework/Modules/SwiftSignalKit.swiftmodule/arm64-apple-ios.swiftdoc: No such file or directory

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ERROR: Skipping '@rules_xcodeproj_generated//generator/Telegram/Telegram_xcodepr
 
 If you encounter this issue, re-run the project generation steps in the README.
 
-## Frameworks issues on MacOS 15.5+: permission denied, no such directory or file
+## XCode build frameworks issues: permission denied, no such directory or file
 
 On MacOS 15.5 and newer you might encounter a Xcode build failure accompainded by this errors:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ERROR: Skipping '@rules_xcodeproj_generated//generator/Telegram/Telegram_xcodepr
 
 If you encounter this issue, re-run the project generation steps in the README.
 
-## XCode build frameworks issues: permission denied, no such directory or file
+## XCode build issues with frameworks: permission denied, no such directory or file
 
 On MacOS 15.5 and newer you might encounter a Xcode build failure accompainded by this errors:
 


### PR DESCRIPTION
## Problem
This PR adds a new FAQ entry to the README addressing build errors related to rsync issues on macOS 15.4 and later. It provides a clear workaround for developers encountering framework build failures such as permission errors or “no such file or directory” messages.

The main goal of this PR is to resolve the rsync problems mentioned in `copy_outputs.sh`:

```
# NOTE: use `which` to find the path to `rsync`.
# On macOS 15.4, the system `rsync` uses `openrsync`, which causes various permission issues.
# This workaround allows users to override the system `rsync` with a working version.
# Remove this once we no longer support macOS versions with broken `rsync`.
PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
  rsync \
  --copy-links \
  --recursive \
  --times \
  --delete \
  ${exclude_list:+--exclude-from="$exclude_list"} \
  --perms \
  --chmod=u+w \
  --out-format="%n%L" \
  "$BAZEL_OUTPUTS_PRODUCT_BASENAME" \
  "$TARGET_BUILD_DIR"
```

## Solution
### XCode build issues with frameworks: permission denied, no such directory or file

On MacOS 15.4 and newer you might encounter a Xcode build failure accompainded by this errors:

```
.../SSignalKit/SwiftSignalKit/SwiftSignalKitFramework.framework/Modules/SwiftSignalKit.swiftmodule/arm64-apple-ios.swiftdoc: No such file or directory
.../MtProtoKit/MtProtoKitFramework.framework/Info.plist': Permission denied (13)
```

If you encounter this issue, install rsync with following command:
```
brew install rsync
```

After installing rsync, clear build folder and rebuild the project.

## Testing
The update was verified by reproducing the README steps using the new FAQ solution, which successfully resolved the previous build issue.