### PR TITLE
Fix iOS m4a audio playback buffer overflow issue

### DIFF
--- a/submodules/FFMpegBinding/Sources/FFMpegSWResample.m
+++ b/submodules/FFMpegBinding/Sources/FFMpegSWResample.m
@@ -72,6 +72,7 @@
         0,
         NULL
     ) != 0) {
+        NSLog(@"[FFMpegSWResample] Failed to allocate SWResample context for channel count %d", channelCount);
         return;
     }
     #else
@@ -89,9 +90,14 @@
     #pragma clang diagnostic pop
     #endif
     _currentSourceChannelCount = channelCount;
-    _ratio = MAX(1, _destinationSampleRate / MAX(_sourceSampleRate, 1)) * MAX(1, _destinationChannelCount / channelCount) * 2;
+    _ratio = MAX(1, _destinationSampleRate / MAX(_sourceSampleRate, 1)) * MAX(1, _destinationChannelCount / channelCount);
     if (_context) {
-        swr_init(_context);
+        int initResult = swr_init(_context);
+        if (initResult < 0) {
+            NSLog(@"[FFMpegSWResample] Failed to initialize SWResample context: %d", initResult);
+            swr_free(&_context);
+            _context = NULL;
+        }
     }
 }
 
@@ -108,14 +114,18 @@
     }
 
     if (!_context) {
+        NSLog(@"[FFMpegSWResample] No valid context available for resampling");
         return nil;
     }
 
     int bufSize = av_samples_get_buffer_size(NULL,
                                              (int)_destinationChannelCount,
-                                             frameImpl->nb_samples * (int)_ratio,
+                                             frameImpl->nb_samples,
                                              (enum AVSampleFormat)_destinationSampleFormat,
                                              1);
+    
+    // Add some padding to prevent buffer overflow
+    bufSize = bufSize * 2;
     
     if (!_buffer || _bufferSize < bufSize) {
         _bufferSize = bufSize;
@@ -126,10 +136,11 @@
     
     int numFrames = swr_convert(_context,
                                 outbuf,
-                                frameImpl->nb_samples * (int)_ratio,
+                                bufSize / (_destinationChannelCount * 2), // Use proper buffer size calculation
                                 (const uint8_t **)frameImpl->data,
                                 frameImpl->nb_samples);
     if (numFrames <= 0) {
+        NSLog(@"[FFMpegSWResample] Resampling failed with result: %d", numFrames);
         return nil;
     }
     

--- a/submodules/MediaPlayer/Sources/FFMpegAudioFrameDecoder.swift
+++ b/submodules/MediaPlayer/Sources/FFMpegAudioFrameDecoder.swift
@@ -14,27 +14,36 @@ final class FFMpegAudioFrameDecoder: MediaTrackFrameDecoder {
     
     private var delayedFrames: [MediaTrackFrame] = []
     
-    init(codecContext: FFMpegAVCodecContext, sampleRate: Int = 44100, channelCount: Int = 2) {
+    init(codecContext: FFMpegAVCodecContext, sampleRate: Int = 44100, channelCount: Int? = nil) {
         self.codecContext = codecContext
         self.audioFrame = FFMpegAVFrame()
         
-        self.swrContext = FFMpegSWResample(sourceChannelCount: Int(codecContext.channels()), sourceSampleRate: Int(codecContext.sampleRate()), sourceSampleFormat: codecContext.sampleFormat(), destinationChannelCount: channelCount, destinationSampleRate: sampleRate, destinationSampleFormat: FFMPEG_AV_SAMPLE_FMT_S16)
+        // Use actual channel count from codec context, but ensure at least stereo for iOS compatibility
+        let actualChannelCount = Int(codecContext.channels())
+        let targetChannelCount = channelCount ?? max(actualChannelCount, 2)
+        
+        self.swrContext = FFMpegSWResample(sourceChannelCount: actualChannelCount, sourceSampleRate: Int(codecContext.sampleRate()), sourceSampleFormat: codecContext.sampleFormat(), destinationChannelCount: targetChannelCount, destinationSampleRate: sampleRate, destinationSampleFormat: FFMPEG_AV_SAMPLE_FMT_S16)
         
         var outputDescription = AudioStreamBasicDescription(
             mSampleRate: Float64(sampleRate),
             mFormatID: kAudioFormatLinearPCM,
             mFormatFlags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsPacked,
-            mBytesPerPacket: UInt32(2 * channelCount),
+            mBytesPerPacket: UInt32(2 * targetChannelCount),
             mFramesPerPacket: 1,
-            mBytesPerFrame: UInt32(2 * channelCount),
-            mChannelsPerFrame: UInt32(channelCount),
+            mBytesPerFrame: UInt32(2 * targetChannelCount),
+            mChannelsPerFrame: UInt32(targetChannelCount),
             mBitsPerChannel: 16,
             mReserved: 0
         )
         
         var channelLayout = AudioChannelLayout()
         memset(&channelLayout, 0, MemoryLayout<AudioChannelLayout>.size)
-        channelLayout.mChannelLayoutTag = kAudioChannelLayoutTag_Mono
+        // Use appropriate channel layout based on target channel count
+        if targetChannelCount == 1 {
+            channelLayout.mChannelLayoutTag = kAudioChannelLayoutTag_Mono
+        } else {
+            channelLayout.mChannelLayoutTag = kAudioChannelLayoutTag_Stereo
+        }
         
         var formatDescription: CMAudioFormatDescription?
         CMAudioFormatDescriptionCreate(allocator: nil, asbd: &outputDescription, layoutSize: MemoryLayout<AudioChannelLayout>.size, layout: &channelLayout, magicCookieSize: 0, magicCookie: nil, extensions: nil, formatDescriptionOut: &formatDescription)

--- a/submodules/MediaPlayer/Sources/FFMpegMediaFrameSourceContext.swift
+++ b/submodules/MediaPlayer/Sources/FFMpegMediaFrameSourceContext.swift
@@ -546,7 +546,7 @@ final class FFMpegMediaFrameSourceContext: NSObject {
                             startTime = CMTimeMake(value: rawStartTime, timescale: timebase.timescale)
                         }
                         
-                        audioStream = StreamContext(index: Int(streamIndex), codecContext: codecContext, fps: fps, timebase: timebase, startTime: startTime, duration: duration, decoder: FFMpegAudioFrameDecoder(codecContext: codecContext), rotationAngle: 0.0, aspect: 1.0)
+                        audioStream = StreamContext(index: Int(streamIndex), codecContext: codecContext, fps: fps, timebase: timebase, startTime: startTime, duration: duration, decoder: FFMpegAudioFrameDecoder(codecContext: codecContext, sampleRate: Int(codecContext.sampleRate())), rotationAngle: 0.0, aspect: 1.0)
                         break
                     }
                 }


### PR DESCRIPTION
- Remove arbitrary * 2 multiplier from SWResample ratio calculation
- Fix buffer size calculation to prevent overflow
- Add proper error handling and logging
- Dynamic channel detection for better compatibility

Fixes: https://bugs.telegram.org/c/55223