### PR TITLE
Fix URL parameter for addToHomeScreen

### DIFF
--- a/submodules/WebUI/Sources/WebAppController.swift
+++ b/submodules/WebUI/Sources/WebAppController.swift
@@ -3200,7 +3200,7 @@ public final class WebAppController: ViewController, AttachmentContainable {
                 } else {
                     scheme = "https"
                 }
-                let url = URL(string: "\(scheme)://t.me/\(addressName)\(appName)?startapp&addToHomeScreen")!
+                let url = URL(string: "\(scheme)://t.me/\(addressName)\(appName)?startapp=addToHomeScreen")!
                 UIApplication.shared.open(url)
             })
         }


### PR DESCRIPTION
Fix for https://github.com/TelegramMessenger/Telegram-iOS/issues/1979 (a typo in URL: `startapp&addToHomeScreen` instead of `startapp=addToHomeScreen`, which leads to not passing of addToHomeScreen into a Mini App start_params and URL params)