### PR TITLE
Siri matching for non-Telegram Contacts with open chat and iOS Contact using peer id URL - bots allowed if all conditions met

### DIFF
--- a/Telegram/SiriIntents/IntentContacts.swift
+++ b/Telegram/SiriIntents/IntentContacts.swift
@@ -117,6 +117,33 @@ func matchingCloudContacts(postbox: Postbox, contacts: [MatchingDeviceContact]) 
     }
 }
 
+func matchingOpenChatWithDeviceContacts(postbox: Postbox, contacts: [MatchingDeviceContact]) -> Signal<[(String, TelegramUser)], NoError> {
+    return postbox.transaction { transaction -> [(String, TelegramUser)] in
+        var result: [(String, TelegramUser)] = []
+        let contactPeerIds = transaction.getContactPeerIds()
+        
+        outer: for peerId in transaction.chatListGetAllPeerIds(groupId: .root) {
+            if contactPeerIds.contains(peerId) {
+                continue
+            }
+            if peerId.namespace != Namespaces.Peer.CloudUser {
+                continue
+            }
+            guard let user = transaction.getPeer(peerId) as? TelegramUser, !user.isDeleted else {
+                continue
+            }
+            for contact in contacts {
+                if let contactPeerId = contact.peerId, contactPeerId == peerId {
+                    result.append((contact.stableId, user))
+                    continue outer
+                }
+            }
+        }
+        
+        return result
+    }
+}
+
 func matchingCloudContact(postbox: Postbox, peerId: PeerId) -> Signal<TelegramUser?, NoError> {
     return postbox.transaction { transaction -> TelegramUser? in
         if let user = transaction.getPeer(peerId) as? TelegramUser {

--- a/Telegram/SiriIntents/IntentHandler.swift
+++ b/Telegram/SiriIntents/IntentHandler.swift
@@ -335,7 +335,15 @@ class DefaultIntentHandler: INExtension, INSendMessageIntentHandling, INSearchFo
             |> castError(IntentContactsError.self)
             |> mapToSignal { account -> Signal<[(String, TelegramUser)], IntentContactsError> in
                 if let account = account {
-                    return matchingCloudContacts(postbox: account.postbox, contacts: matchedContacts)
+                    return combineLatest(
+                        matchingCloudContacts(postbox: account.postbox, contacts: matchedContacts),
+                        matchingOpenChatWithDeviceContacts(postbox: account.postbox, contacts: matchedContacts)
+                    )
+                    |> map { cloudContacts, openChatContacts in
+                        var result = cloudContacts
+                        result.append(contentsOf: openChatContacts)
+                        return result
+                    }
                     |> castError(IntentContactsError.self)
                 } else {
                     return .fail(.generic)

--- a/Telegram/SiriIntents/IntentHandler.swift
+++ b/Telegram/SiriIntents/IntentHandler.swift
@@ -335,14 +335,19 @@ class DefaultIntentHandler: INExtension, INSendMessageIntentHandling, INSearchFo
             |> castError(IntentContactsError.self)
             |> mapToSignal { account -> Signal<[(String, TelegramUser)], IntentContactsError> in
                 if let account = account {
-                    return combineLatest(
-                        matchingCloudContacts(postbox: account.postbox, contacts: matchedContacts),
-                        matchingOpenChatWithDeviceContacts(postbox: account.postbox, contacts: matchedContacts)
-                    )
-                    |> map { cloudContacts, openChatContacts in
-                        var result = cloudContacts
-                        result.append(contentsOf: openChatContacts)
-                        return result
+                    return matchingCloudContacts(postbox: account.postbox, contacts: matchedContacts)
+                    |> mapToSignal { cloudContacts -> Signal<[(String, TelegramUser)], NoError> in
+                        let matchedStableIds = Set(cloudContacts.map { $0.0 })
+                        let unmatchedContacts = matchedContacts.filter { !matchedStableIds.contains($0.stableId) }
+                        if unmatchedContacts.isEmpty {
+                            return .single(cloudContacts)
+                        }
+                        return matchingOpenChatWithDeviceContacts(postbox: account.postbox, contacts: unmatchedContacts)
+                        |> map { openChatContacts -> [(String, TelegramUser)] in
+                            var result = cloudContacts
+                            result.append(contentsOf: openChatContacts)
+                            return result
+                        }
                     }
                     |> castError(IntentContactsError.self)
                 } else {


### PR DESCRIPTION
## Summary

Fixes #1960: allow Siri recipient resolution for Telegram bots (which cannot be Telegram contacts) by matching an iOS Contact URL that encodes the bot peer id.

## What Changed

- Kept existing Siri contact matching behavior for Telegram contacts/phone numbers.
- Added a separate open-chat matcher for non-contact `CloudUser` peers in the root chat list.
- Bot/open-chat matching only runs for device contacts that were **not** already matched by existing cloud-contact logic (to avoid changing already-matched behavior).

## How To Use / Verify

1. Create a Telegram bot with BotFather.
2. Get the bot id from the HTTP token (the number to the left of `:`).
3. Create an iOS Contact with a Siri-distinguishable first name (example: `Cookie`).
4. In that contact, tap `add url`.
5. Change the URL label from `homepage` to custom label `Telegram` (case-sensitive).
6. Set URL to `https://t.me/@id<bot_id>` (example: `https://t.me/@id12345678`).
7. Install this local Telegram build.
8. Ensure there is an active DM/open chat with the bot in the root chat list.
9. Say: `Siri, message Cookie on Telegram`  
   Expected: Telegram opens with the correct bot target.
10. Say: `Siri, message Cookie`  
    Expected: also resolves correctly when the contact has no competing phone/contact data.
11. With CarPlay `Siri, message Cookie`
    Expected: resolves correctly and sends the message

## Security Concerns

Bots do not appear to be eligible to be saved as contacts in Telegram.  This means we cannot signal that we want to be able to address a bot (e.g. an OpenClaw bot private to the user) by saving them as a Contact in Telegram.

Allowing arbitrary matches with any open bot conversation, or matching by `@usernamebot`, would be risky as it could lead to bots stealing conversations meant for other users, simply by changing their name or by a bot getting deleted and recreated by another owner with the same username.

Creating an iOS Contact with a Peer ID-specific URL is an intentional act that is a strong indication that the user wants to talk to this bot.  This also gives it a name that will be stable that is outside of control of the bot or any other user on Telegram.