### PR TITLE
Fix: respect external USB-C microphone input during voice message recording

### DIFF
--- a/submodules/TelegramAudio/Sources/ManagedAudioSession.swift
+++ b/submodules/TelegramAudio/Sources/ManagedAudioSession.swift
@@ -1065,6 +1065,17 @@ public final class ManagedAudioSessionImpl: NSObject, ManagedAudioSession {
             switch updatedType {
                 case .record(false, _, _):
                     try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
+                    // overrideOutputAudioPort(.speaker) forces both output AND input
+                    // to built-in devices. If an external input device (e.g. USB-C
+                    // microphone) is connected, restore it as the preferred input.
+                    if let routes = AVAudioSession.sharedInstance().availableInputs {
+                        for route in routes {
+                            if route.portType != .builtInMic && !bluetoothPortTypes.contains(route.portType) && route.portType != .headphones {
+                                let _ = try? AVAudioSession.sharedInstance().setPreferredInput(route)
+                                break
+                            }
+                        }
+                    }
                 case .voiceCall, .playWithPossiblePortOverride, .record(true, _, _):
                     try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none)
                     if let routes = AVAudioSession.sharedInstance().availableInputs {


### PR DESCRIPTION
## Problem

When recording voice messages with an external USB-C microphone (e.g. BOYA Mini 2 wireless mic receiver), Telegram ignores the external device and records from the built-in microphone instead.

This happens because `setupOutputMode` calls `overrideOutputAudioPort(.speaker)` for voice message recording (`.record(false, _, _)`). Per [Apple docs](https://developer.apple.com/documentation/avfaudio/avaudiosession/overrideoutputaudioport(_:)), this forces **both** output and input to built-in devices, regardless of other settings.

Other apps (Voice Memos, Camera) correctly use the external microphone. The user can verify the device is recognized in iOS Settings > Sounds & Haptics > Input.

Related: #1195, bugs.telegram.org/c/58429

## Fix

After the speaker override, check `availableInputs` for connected external input devices (excluding built-in mic, Bluetooth, and wired headphones) and restore them as the preferred input via `setPreferredInput`.

- **11 lines added, 0 removed**
- No behavior change when no external device is connected
- Uses `try?` so failures don't affect existing flows
- Tested with BOYA Mini 2 USB-C wireless mic on iPhone 17 Pro Max / iOS 26

## Diff

```swift
case .record(false, _, _):
    try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
    // overrideOutputAudioPort(.speaker) forces both output AND input
    // to built-in devices. If an external input device (e.g. USB-C
    // microphone) is connected, restore it as the preferred input.
    if let routes = AVAudioSession.sharedInstance().availableInputs {
        for route in routes {
            if route.portType != .builtInMic && !bluetoothPortTypes.contains(route.portType) && route.portType != .headphones {
                let _ = try? AVAudioSession.sharedInstance().setPreferredInput(route)
                break
            }
        }
    }
```