### PR TITLE
Fix: Hide size label when cache is cleared to prevent checkmark overlap.

### DIFF
--- a/submodules/TelegramUI/Components/StorageUsageScreen/Sources/StorageUsageScreen.swift
+++ b/submodules/TelegramUI/Components/StorageUsageScreen/Sources/StorageUsageScreen.swift
@@ -1697,6 +1697,8 @@ final class StorageUsageScreenComponent: Component {
                     }
                     let totalLabelFrame = CGRect(origin: CGPoint(x: pieChartFrame.minX + floor((pieChartFrame.width - chartTotalLabelSize.width) / 2.0), y: pieChartFrame.minY + floor((pieChartFrame.height - chartTotalLabelSize.height) / 2.0)), size: chartTotalLabelSize)
                     transition.setFrame(view: chartTotalLabelView, frame: totalLabelFrame)
+                    // Hide the size label when storage is cleared to avoid overlap with checkmark
+                    chartTotalLabelView.isHidden = listCategories.isEmpty
                     transition.setAlpha(view: chartTotalLabelView, alpha: listCategories.isEmpty ? 0.0 : 1.0)
                 }
             }


### PR DESCRIPTION
Hey! 👋

I noticed a small UI bug while using Telegram on iOS.

**The issue:**
When you clear the cache in Settings > Data and Storage > Storage Usage, the "0 B" text overlaps with the green checkmark icon. It looks a bit off.

**Screenshot:**
![Screenshot](https://github.com/user-attachments/assets/023a7312-16eb-4789-bd0a-09b79209b703)


**What I changed:**
Added `chartTotalLabelView.isHidden = listCategories.isEmpty` to hide the size label when the cache is fully cleared, so it doesn't overlap with the success checkmark.

**File modified:**
`submodules/TelegramUI/Components/StorageUsageScreen/Sources/StorageUsageScreen.swift`

This is my first contribution, happy to make any changes if needed!