### PR TITLE
Fix TLS ClientHello fingerprint: add ECH extension (iOS TSPU bypass)

### DIFF
--- a/submodules/MtProtoKit/Sources/MTTcpConnection.m
+++ b/submodules/MtProtoKit/Sources/MTTcpConnection.m
@@ -306,13 +306,13 @@ static bool parseIntArgument(NSString *string, HelloParseState *state, int *outp
 }
 
 static NSMutableData *executeGenerationCode(id<EncryptionProvider> provider, NSData *domain) {
-    NSString *code = @"S \"\\x16\\x03\\x01\\x02\\x00\\x01\\x00\\x01\\xfc\\x03\\x03\"\n"
+    NSString *code = @"S \"\\x16\\x03\\x01\\x02\\x24\\x01\\x00\\x02\\x20\\x03\\x03\"\n"
                       "Z 32\n"
                       "S \"\\x20\"\n"
                       "R 32\n"
                       "S \"\\x00\\x2a\"\n"
                       "G 0\n"
-                      "S \"\\x13\\x01\\x13\\x02\\x13\\x03\\xc0\\x2c\\xc0\\x2b\\xcc\\xa9\\xc0\\x30\\xc0\\x2f\\xcc\\xa8\\xc0\\x0a\\xc0\\x09\\xc0\\x14\\xc0\\x13\\x00\\x9d\\x00\\x9c\\x00\\x35\\x00\\x2f\\xc0\\x08\\xc0\\x12\\x00\\x0a\\x01\\x00\\x01\\x89\"\n"
+                      "S \"\\x13\\x01\\x13\\x02\\x13\\x03\\xc0\\x2c\\xc0\\x2b\\xcc\\xa9\\xc0\\x30\\xc0\\x2f\\xcc\\xa8\\xc0\\x0a\\xc0\\x09\\xc0\\x14\\xc0\\x13\\x00\\x9d\\x00\\x9c\\x00\\x35\\x00\\x2f\\xc0\\x08\\xc0\\x12\\x00\\x0a\\x01\\x00\\x01\\xad\"\n"
                       "G 2\n"
                       "S \"\\x00\\x00\\x00\\x00\"\n"
                       "[\n"
@@ -332,6 +332,8 @@ static NSMutableData *executeGenerationCode(id<EncryptionProvider> provider, NSD
                       "S \"\\x00\\x2d\\x00\\x02\\x01\\x01\\x00\\x2b\\x00\\x0b\\x0a\"\n"
                       "G 6\n"
                       "S \"\\x03\\x04\\x03\\x03\\x03\\x02\\x03\\x01\\x00\\x1b\\x00\\x03\\x02\\x00\\x01\"\n"
+                      "S \"\\xfe\\x0d\\x00\\x20\"\n"
+                      "R 32\n"
                       "G 3\n"
                       "S \"\\x00\\x01\\x00\"\n";
 


### PR DESCRIPTION
## Fix TLS ClientHello fingerprint on iOS: add ECH extension

  ### Problem

  On April 1, 2026, Russian DPI systems (TSPU) deployed a new `TELEGRAM_TLS` signature that
  fingerprints the TLS ClientHello sent by Telegram clients when connecting through MTProto proxies.
  This broke MTProto proxy connectivity for millions of users in Russia.

  Desktop was fixed in v6.7.2 (commit 407bf196), Android has PR
  https://github.com/DrKLO/Telegram/pull/1949. **iOS remains unpatched.**

  ### Root cause on iOS

  The iOS ClientHello (generated in `MtProtoKit/MTTcpConnection.m`, function `executeGenerationCode`)
  has a **different issue** than Desktop/Android:

  - Desktop/Android had extension `0xFE02` (wrong ID) and 20-byte X25519 key share (should be 32). iOS
   never had these bugs.
  - **iOS is missing the ECH extension (`0xFE0D`) entirely.** Every modern browser (Chrome, Safari,
  Firefox) includes this extension since 2024. Its absence makes the iOS ClientHello trivially
  distinguishable from real browser traffic.
  - The fixed 512-byte ClientHello size is another known detection marker.

  ### Fix

  Add ECH extension (`0xFE0D`) with 32 bytes of random data to the ClientHello template. Update three
  hardcoded length fields to account for the additional 36 bytes:

  | Field | Before | After |
  |-------|--------|-------|
  | TLS record payload | 512 (0x0200) | 548 (0x0224) |
  | Handshake payload | 508 (0x01FC) | 544 (0x0220) |
  | Extensions length | 393 (0x0189) | 429 (0x01AD) |

  This also breaks the fixed 512-byte fingerprint as a side effect.

  ### Change

  One file, three surgical edits:
  1. Update record + handshake lengths in the header
  2. Update extensions length
  3. Insert ECH extension (2 new lines) before the final GREASE extension

  ### Analysis

  Detailed technical analysis of the TSPU detection mechanisms: https://habr.com/ru/articles/1018740/

  ---

  *This PR was researched and implemented with help from Claude (Anthropic). The analysis involved
  reverse-engineering the TSPU `TELEGRAM_TLS` signature, comparing Desktop/Android/iOS ClientHello
  templates, and identifying that iOS had a different fingerprinting issue than the other platforms.*