### PR TITLE
Fix: allow AirPlay audio routing during media playback

### DIFF
--- a/submodules/TelegramAudio/Sources/ManagedAudioSession.swift
+++ b/submodules/TelegramAudio/Sources/ManagedAudioSession.swift
@@ -866,12 +866,14 @@ public final class ManagedAudioSessionImpl: NSObject, ManagedAudioSession {
                     if mixWithOthers {
                         options.insert(.mixWithOthers)
                     }
+                    options.insert(.allowAirPlay)
                 case .ambient:
                     options.insert(.mixWithOthers)
                 case .playWithPossiblePortOverride:
                     if case .playAndRecord = nativeCategory {
                         options.insert(.allowBluetoothA2DP)
                     }
+                    options.insert(.allowAirPlay)
                 case .voiceCall, .videoCall:
                     #if canImport(AlarmKit) //Xcode 26
                     options.insert(.allowBluetoothHFP)

--- a/submodules/TelegramUniversalVideoContent/Sources/PlatformVideoContent.swift
+++ b/submodules/TelegramUniversalVideoContent/Sources/PlatformVideoContent.swift
@@ -186,6 +186,7 @@ private final class PlatformVideoContentNode: ASDisplayNode, UniversalVideoConte
         self.imageNode = TransformImageNode()
         
         let player = AVPlayer(playerItem: nil)
+        player.allowsExternalPlayback = true
         self.player = player
         
         self.playerNode = ASDisplayNode()

--- a/submodules/TelegramUniversalVideoContent/Sources/SystemVideoContent.swift
+++ b/submodules/TelegramUniversalVideoContent/Sources/SystemVideoContent.swift
@@ -100,6 +100,7 @@ private final class SystemVideoContentNode: ASDisplayNode, UniversalVideoContent
         
         self.playerItem = AVPlayerItem(url: URL(string: url)!)
         let player = AVPlayer(playerItem: self.playerItem)
+        player.allowsExternalPlayback = true
         self.player = player
         
         self.playerNode = ASDisplayNode()


### PR DESCRIPTION
## Summary

- Add `.allowAirPlay` to audio session category options for `.play` and `.playWithPossiblePortOverride` session types, consistent with existing `.allowBluetoothA2DP` routing options
- Explicitly set `allowsExternalPlayback = true` on AVPlayer instances in `PlatformVideoContent` and `SystemVideoContent` to document external playback intent

## Motivation

The audio session configuration currently includes `.allowBluetoothA2DP` for wireless audio routing but omits `.allowAirPlay`, which prevents proper AirPlay audio routing during media playback. This is an inconsistency in the wireless audio routing configuration.

## Changes

- `ManagedAudioSession.swift`: Add `.allowAirPlay` option for `.play` and `.playWithPossiblePortOverride` session types
- `PlatformVideoContent.swift`: Explicitly enable `allowsExternalPlayback` on AVPlayer
- `SystemVideoContent.swift`: Explicitly enable `allowsExternalPlayback` on AVPlayer

## Test plan

- [ ] Verify media playback works normally without AirPlay devices present
- [ ] Verify AirPlay audio routing is available during media playback when AirPlay devices are on the network
- [ ] Verify no regression in Bluetooth A2DP audio routing
- [ ] Verify PiP functionality is unaffected