### PR TITLE
Fix animated emoji in bot button icons

### DIFF
--- a/submodules/TelegramUI/Components/Chat/ChatButtonKeyboardInputNode/Sources/ChatButtonKeyboardInputNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatButtonKeyboardInputNode/Sources/ChatButtonKeyboardInputNode.swift
@@ -164,9 +164,9 @@ private final class ChatButtonKeyboardInputButtonNode: HighlightTrackingButtonNo
                         size: iconSize,
                         placeholderColor: theme.overallDarkAppearance ? UIColor(white: 1.0, alpha: 0.1) : UIColor(white: 0.0, alpha: 0.1),
                         themeColor: theme.list.itemPrimaryTextColor,
-                        loopMode: .count(0)
+                        loopMode: .forever
                     ),
-                    isVisibleForAnimations: true,
+                    isVisibleForAnimations: context.sharedContext.energyUsageSettings.loopEmoji,
                     action: nil
                 )),
                 environment: {},

--- a/submodules/TelegramUI/Components/Chat/ChatMessageActionButtonsNode/Sources/ChatMessageActionButtonsNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageActionButtonsNode/Sources/ChatMessageActionButtonsNode.swift
@@ -558,9 +558,9 @@ private final class ChatMessageActionButtonNode: ASDisplayNode {
                                     size: emojiIconSize,
                                     placeholderColor: theme.theme.overallDarkAppearance ? UIColor(white: 1.0, alpha: 0.1) : UIColor(white: 0.0, alpha: 0.1),
                                     themeColor: titleColor,
-                                    loopMode: .count(0)
+                                    loopMode: .forever
                                 ),
-                                isVisibleForAnimations: true,
+                                isVisibleForAnimations: context.sharedContext.energyUsageSettings.loopEmoji,
                                 action: nil
                             )),
                             environment: {},


### PR DESCRIPTION
## Summary
- allow custom emoji icons in bot inline/reply buttons to animate
- keep playback gated by the existing animated emoji energy-saving setting

## Context
This matches the existing behavior in Telegram for macOS, where custom emoji icons in bot buttons animate instead of staying static.

## Testing
Not run locally; local environment is not currently configured with the required full Xcode/Bazel setup.