### PR TITLE
Add haptic feedback when crossing media message boundaries

### DIFF
--- a/submodules/GalleryUI/Sources/GalleryController.swift
+++ b/submodules/GalleryUI/Sources/GalleryController.swift
@@ -1706,6 +1706,9 @@ public class GalleryController: ViewController, StandalonePresentableController,
         }
         
         self.galleryNode.pager.replaceItems(items, centralItemIndex: centralItemIndex)
+        if let centralItemIndex = centralItemIndex, centralItemIndex < self.entries.count {
+            self.currentBoundaryId = galleryEntryBoundaryId(self.entries[centralItemIndex])
+        }
         
         self.galleryNode.pager.centralItemIndexUpdated = { [weak self] index in
             if let strongSelf = self {

--- a/submodules/GalleryUI/Sources/GalleryController.swift
+++ b/submodules/GalleryUI/Sources/GalleryController.swift
@@ -654,6 +654,19 @@ public struct GalleryEntry {
     }
 }
 
+private enum GalleryEntryBoundaryId: Equatable {
+    case message(UInt32)
+    case group(UInt32)
+}
+
+private func galleryEntryBoundaryId(_ entry: GalleryEntry) -> GalleryEntryBoundaryId {
+    if let groupId = entry.entry.message.groupInfo?.stableId {
+        return .group(groupId)
+    } else {
+        return .message(entry.entry.message.stableId)
+    }
+}
+
 private func galleryEntriesForMessageHistoryEntries(_ entries: [MessageHistoryEntry], mediaSubject: GalleryMediaSubject?) -> [GalleryEntry] {
     var results: [GalleryEntry] = []
     for entry in entries {
@@ -749,6 +762,8 @@ public class GalleryController: ViewController, StandalonePresentableController,
     private let baseNavigationController: NavigationController?
     
     private var hiddenMediaManagerIndex: Int?
+    private let boundaryHaptic = HapticFeedback()
+    private var currentBoundaryId: GalleryEntryBoundaryId?
     
     private let actionInteraction: GalleryControllerActionInteraction?
     private var performAction: (GalleryControllerInteractionTapAction) -> Void
@@ -816,6 +831,7 @@ public class GalleryController: ViewController, StandalonePresentableController,
         }
         
         self.titleView = GalleryTitleView(context: context, presentationData: self.presentationData)
+        self.boundaryHaptic.prepareTap()
         
         super.init(navigationBarPresentationData: NavigationBarPresentationData(theme: GalleryController.darkNavigationTheme, strings: NavigationBarStrings(presentationStrings: self.presentationData.strings)))
         
@@ -1697,7 +1713,13 @@ public class GalleryController: ViewController, StandalonePresentableController,
                 if let index = index {
                     let entry = strongSelf.entries[index]
                     let message = strongSelf.entries[index].entry.message
-                                        
+                    let boundaryId = galleryEntryBoundaryId(entry)
+                    if let currentBoundaryId = strongSelf.currentBoundaryId, currentBoundaryId != boundaryId {
+                        strongSelf.boundaryHaptic.tap()
+                    }
+                    strongSelf.currentBoundaryId = boundaryId
+                    strongSelf.boundaryHaptic.prepareTap()
+                                         
                     strongSelf.centralEntryStableId = entry.stableId
                     if let selectedMedia = selectedMediaForMessage(message: message, mediaSubject: entry.mediaSubject) {
                         hiddenItem = (message.id, selectedMedia)


### PR DESCRIPTION
## Summary
- Adds a light selection haptic when swiping in the gallery from one media message/group to another.
- Treats grouped media albums as one boundary using `groupInfo.stableId`.
- Initializes the current boundary on gallery open so the first boundary transition also triggers feedback.

## Behavior
- No haptic when moving between items in the same media group.
- Haptic when moving from one group/message to another, including single-image messages.

## Testing
- Tested on simulator with temporary on-screen debug indication at the same trigger point, since simulator does not produce physical haptic feedback.
- Verified the indication appears only when moving to a different media message/group, and not when moving within the same media group.