### PR TITLE
Fix video playback position reset to 0:00 on full-screen close

### DIFF
--- a/submodules/GalleryUI/Sources/Items/UniversalVideoGalleryItem.swift
+++ b/submodules/GalleryUI/Sources/Items/UniversalVideoGalleryItem.swift
@@ -2411,13 +2411,11 @@ final class UniversalVideoGalleryItemNode: ZoomableContentGalleryItemNode {
         shouldStorePlaybacksState = status.duration >= 20.0
         
         if shouldStorePlaybacksState {
-            var timestamp: Double?
             if status.timestamp > 5.0 && status.timestamp < status.duration - 5.0 {
-                timestamp = status.timestamp
-            } else {
-                timestamp = 0.0
+                item.storeMediaPlaybackState(message.id, status.timestamp, status.baseRate)
+            } else if status.timestamp >= status.duration - 5.0 {
+                item.storeMediaPlaybackState(message.id, 0.0, status.baseRate)
             }
-            item.storeMediaPlaybackState(message.id, timestamp, status.baseRate)
         } else {
             item.storeMediaPlaybackState(message.id, nil, status.baseRate)
         }


### PR DESCRIPTION
Addresses the resume regression in #1922 (the primary symptom; the issue's inline-preview "continuity" point is a separate behavior change and is not included here).

**Problem.** Partially-watched videos always restart at `0:00` instead of resuming.

**Cause.** `UniversalVideoGalleryItemNode.maybeStorePlaybackStatus` persists the position from *every* `videoNode.status` update. On full-screen close the player resets and emits a final status with `timestamp ≈ 0`; the old `else` branch wrote `0.0`, overwriting the saved position on every close, so the stored resume point ends up `0` and the next open starts at `0:00`.

**Runtime trace** (play to ~0:16, close, re-open):
```
before:  store 16.0  →  store 0.0  (teardown reset overwrites it)  →  read 0.0  →  seek 0  →  0:00
after:   read 5.3 / read 8.5  (saved position survives)            →  resumes
```

## After fix (skip to 0:19s)

https://github.com/user-attachments/assets/3bafeb9f-fd88-45a5-9f02-ba047a8b99c6
