### PR TITLE
Fix crash: guard DrawingContext against a null image buffer (SIGSEGV)

### DIFF
--- a/submodules/Display/Source/GenerateImage.swift
+++ b/submodules/Display/Source/GenerateImage.swift
@@ -638,6 +638,15 @@ public class DrawingContext {
         self.length = self.bytesPerRow * Int(scaledSize.height)
 
         self.imageBuffer = ASCGImageBuffer(length: UInt(self.length))
+        if Int(bitPattern: self.imageBuffer.mutableBytes) == 0 {
+            // malloc(length) failed (e.g. an oversized allocation from a bad
+            // drawingSize). CGContext(data: nil, ...) below would silently
+            // succeed using CG's own internal buffer, masking the failure
+            // until the later memset(self.bytes, ...) writes through this
+            // null pointer and segfaults. Fail the init instead, matching
+            // the other guarded failure paths in this initializer.
+            return nil
+        }
 
         if opaque {
             self.bitmapInfo = DeviceGraphicsContextSettings.shared.opaqueBitmapInfo


### PR DESCRIPTION
## Why

`ASCGImageBuffer.initWithLength:` calls `malloc(length)` with no null check. When `length` is oversized (e.g. from a bad `drawingSize` computed during chat photo layout), `malloc` can return `NULL`.

`CGContext(data: nil, ...)` inside `DrawingContext.init` silently succeeds anyway — CoreGraphics falls back to its own internally-managed buffer, masking the allocation failure. The later `memset(self.bytes, 0, self.length)` in the same initializer then writes through the still-null `imageBuffer.mutableBytes` pointer and segfaults.

Confirmed via an on-device crash report: `ESR = Data Abort, byte write Translation fault`, `FAR (fault address) = 0x0`, with `__bzero` and `ASCGImageBuffer` visible in nearby registers — a real device crash while scrolling a chat with photos.

## Fix

Fail the initializer gracefully (`return nil`) as soon as the buffer allocation comes back null, matching the other guarded failure paths already present in this same initializer (non-positive size, `CGContext` creation failure). Callers of `DrawingContext.init` already handle a `nil` result throughout the codebase.

## Testing

Verified against the crash report that triggered this (register state showed a null-pointer write inside `memset`/`ASCGImageBuffer`). Built and ran on-device (iPhone, iOS 26.5) across normal chat/photo usage after the fix; no functional regression, no follow-up allocation-related crashes observed.