### PR TITLE
Fix crash: disable in-chat SwiftUI translation service (fatal trap in Translation framework internals)

### DIFF
--- a/submodules/TelegramUI/Sources/Chat/ChatControllerLoadDisplayNode.swift
+++ b/submodules/TelegramUI/Sources/Chat/ChatControllerLoadDisplayNode.swift
@@ -683,12 +683,22 @@ extension ChatControllerImpl {
             }
         }
         
-        if #available(iOS 18.0, *) {
-            if engineExperimentalInternalTranslationService == nil, let hostView = self.context.sharedContext.mainWindow?.hostView {
-                let translationService = ExperimentalInternalTranslationServiceImpl(view: hostView.containerView)
-                engineExperimentalInternalTranslationService = translationService
-            }
-        }
+        // Disabled: ExperimentalInternalTranslationServiceImpl.init constructs a
+        // UIHostingController(rootView: TranslationViewImpl(...)) that fatal-traps
+        // inside SwiftUI/Translation-framework internals on device (SIGABRT, no
+        // application-code frames at the trap site — confirmed on iOS 26.5,
+        // reproducible on the first chat opened per app session). A trap inside
+        // Apple's own framework code cannot be guarded or caught from Swift, so
+        // the only available mitigation is not calling into it. Re-enable once
+        // the underlying SwiftUI + .translationTask interop bug is understood
+        // or fixed by an OS update.
+        //
+        // if #available(iOS 18.0, *) {
+        //     if engineExperimentalInternalTranslationService == nil, let hostView = self.context.sharedContext.mainWindow?.hostView {
+        //         let translationService = ExperimentalInternalTranslationServiceImpl(view: hostView.containerView)
+        //         engineExperimentalInternalTranslationService = translationService
+        //     }
+        // }
         
         self.displayNode = ChatControllerNode(context: self.context, chatLocation: self.chatLocation, chatLocationContextHolder: self.chatLocationContextHolder, subject: self.subject, controllerInteraction: self.controllerInteraction!, chatPresentationInterfaceState: self.presentationInterfaceState, automaticMediaDownloadSettings: self.automaticMediaDownloadSettings, navigationBar: self.navigationBar, statusBar: self.statusBar, backgroundNode: self.chatBackgroundNode, controller: self)
         


### PR DESCRIPTION
## Why

`ExperimentalInternalTranslationServiceImpl.init` constructs a `UIHostingController(rootView: TranslationViewImpl(...))` that fatal-traps inside SwiftUI/Translation-framework internals on device (`SIGABRT`, no application-code frames at the trap site) — confirmed on iOS 26.5, reproducible on the first chat opened per app session.

A trap inside Apple's own framework code cannot be guarded or caught from Swift, so the only fix available on our side is not calling into it.

## Fix

Disable instantiation of the local/on-device translation service. This is safe: `TelegramCore`'s `translate()` already falls back to server-side translation whenever `engineExperimentalInternalTranslationService` is `nil` (`Translate.swift:228`), which is now unconditionally the case. In-chat message translation keeps working through the existing server-side path; only the on-device fast-path (which currently cannot be used without crashing) is disabled.

Left the original code commented in place with an explanation, to make it easy to re-enable once the underlying SwiftUI + `.translationTask` interop issue is understood or fixed by an OS update.

## Testing

Verified against the crash report that triggered this (`SIGABRT`, trap inside `UIHostingController`/SwiftUI internals immediately following `ExperimentalInternalTranslationServiceImpl.init`, on the first chat opened after launch). Built and ran on-device (iPhone, iOS 26.5): chats now open normally, and message translation via the server-side path still works.


Possibly related to #1739 (reported crash opening any chat after updating to iOS 18.4 — this fix is gated behind `#available(iOS 18.0, *)`, so the onset lining up with an iOS 18+ update is consistent, though I have not been able to confirm against their crash log).
