### PR TITLE
Fix share extension hang when no account is logged in

### DIFF
--- a/submodules/TelegramUI/Components/ShareExtensionContext/Sources/ShareExtensionContext.swift
+++ b/submodules/TelegramUI/Components/ShareExtensionContext/Sources/ShareExtensionContext.swift
@@ -423,9 +423,10 @@ public class ShareRootControllerImpl {
                 isICloudEnabled: false
             )
             
-            let accountData: Signal<(ShareControllerEnvironment, ShareControllerAccountContext, [ShareControllerSwitchableAccount]), NoError> = accountManager.accountRecords()
+            let accountData: Signal<(ShareControllerEnvironment, ShareControllerAccountContext, [ShareControllerSwitchableAccount]), ShareAuthorizationError> = accountManager.accountRecords()
             |> take(1)
-            |> mapToSignal { view -> Signal<(ShareControllerEnvironment, ShareControllerAccountContext, [ShareControllerSwitchableAccount]), NoError> in
+            |> castError(ShareAuthorizationError.self)
+            |> mapToSignal { view -> Signal<(ShareControllerEnvironment, ShareControllerAccountContext, [ShareControllerSwitchableAccount]), ShareAuthorizationError> in
                 var signals: [Signal<(AccountRecordId, AccountStateManager, EnginePeer)?, NoError>] = []
                 for record in view.records {
                     if record.attributes.contains(where: { attribute in
@@ -464,8 +465,12 @@ public class ShareRootControllerImpl {
                         }
                     })
                 }
+                if signals.isEmpty {
+                    return .fail(.unauthorized)
+                }
                 return combineLatest(signals)
-                |> mapToSignal { stateManagers -> Signal<(ShareControllerEnvironment, ShareControllerAccountContext, [ShareControllerSwitchableAccount]), NoError> in
+                |> castError(ShareAuthorizationError.self)
+                |> mapToSignal { stateManagers -> Signal<(ShareControllerEnvironment, ShareControllerAccountContext, [ShareControllerSwitchableAccount]), ShareAuthorizationError> in
                     var allAccounts: [ShareControllerSwitchableAccount] = []
                     for data in stateManagers {
                         guard let (id, stateManager, peer) = data else {
@@ -484,7 +489,7 @@ public class ShareRootControllerImpl {
                     }
                     
                     guard let currentAccount = allAccounts.first(where: { $0.account.accountId == view.currentRecord?.id }) else {
-                        return .never()
+                        return .fail(.unauthorized)
                     }
                     
                     return .single((environment, currentAccount.account, allAccounts))
@@ -492,7 +497,6 @@ public class ShareRootControllerImpl {
             }
             
             let applicationInterface: Signal<(ShareControllerEnvironment, ShareControllerAccountContext, PostboxAccessChallengeData, [ShareControllerSwitchableAccount]), ShareAuthorizationError> = accountData
-            |> castError(ShareAuthorizationError.self)
             |> mapToSignal { data -> Signal<(ShareControllerEnvironment, ShareControllerAccountContext, PostboxAccessChallengeData, [ShareControllerSwitchableAccount]), ShareAuthorizationError> in
                 let (environment, context, otherAccounts) = data
                 


### PR DESCRIPTION
Handle missing or unauthorized accounts as an authorization failure instead of returning a never-ending signal, allowing the share extension to present the existing login prompt and complete cleanly.

Fixes #2134.
