### PR TITLE
Add CASVA to the Open location in list

### DIFF
--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -1610,6 +1610,7 @@ plist_fragment(
         <string>moovit</string>
         <string>alook</string>
         <string>dgis</string>
+        <string>casva</string>
         <string>microsoft-edge-http</string>
         <string>brave</string>
         <string>onionhttp</string>

--- a/Telegram/Telegram-iOS/Info.plist
+++ b/Telegram/Telegram-iOS/Info.plist
@@ -259,6 +259,7 @@
 		<string>moovit</string>
 		<string>alook</string>
 		<string>dgis</string>
+		<string>casva</string>
 		<string>microsoft-edge-http</string>
 		<string>brave</string>
 		<string>onionhttp</string>

--- a/Telegram/Telegram-iOS/InfoBazel.plist
+++ b/Telegram/Telegram-iOS/InfoBazel.plist
@@ -93,6 +93,7 @@
 		<string>moovit</string>
 		<string>alook</string>
 		<string>dgis</string>
+		<string>casva</string>
 		<string>microsoft-edge-http</string>
 		<string>brave</string>
 		<string>onionhttp</string>

--- a/submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift
+++ b/submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift
@@ -305,6 +305,10 @@ private func allOpenInOptions(context: AccountContext, item: OpenInItem) -> [Ope
                     return .openUrl(url: "dgis://2gis.ru/geo/\(coordinates)")
                 }
             }))
+
+            options.append(OpenInOption(identifier: "casva", application: .other(title: "CASVA", identifier: 1603197837, scheme: "casva", store: "uz"), action: {
+                return .openUrl(url: "casva://location?lat=\(lat)&lon=\(lon)")
+            }))
             
             options.append(OpenInOption(identifier: "moovit", application: .other(title: "Moovit", identifier: 498477945, scheme: "moovit", store: nil), action: {
                 if let _ = directions {


### PR DESCRIPTION
Adds CASVA to the "Open location in…" action sheet, next to the other regional map/navigation apps (Yandex Maps, 2GIS, Yango).

CASVA is a freight/cargo delivery service in Uzbekistan. When a user shares a location in a chat, tapping it and choosing "Open in CASVA" starts a delivery order pre-filled with the shared point.

- App Store: https://apps.apple.com/app/id1603197837 (bundle `uz.casva.app`, App Store id `1603197837`)
- URL scheme handled by the app: `casva://location?lat=<lat>&lon=<lon>`

Changes:
- `submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift` — register the option under `.location`.
- `Telegram/Telegram-iOS/Info.plist`, `Telegram/Telegram-iOS/InfoBazel.plist`, `Telegram/BUILD` — add `casva` to `LSApplicationQueriesSchemes` so `canOpenURL` detects the installed app.

The scheme is live in the current App Store build of CASVA. No assets are bundled: the icon is loaded from the App Store listing via the app id, matching the existing entries.
