### PR TITLE
Add Hamroh (uz.mobilex.hamroh) to Open-in location list

### DIFF
--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -1610,6 +1610,7 @@ plist_fragment(
         <string>moovit</string>
         <string>alook</string>
         <string>dgis</string>
+        <string>hamroh</string>
         <string>microsoft-edge-http</string>
         <string>brave</string>
         <string>onionhttp</string>

--- a/Telegram/Telegram-iOS/Info.plist
+++ b/Telegram/Telegram-iOS/Info.plist
@@ -259,6 +259,7 @@
 		<string>moovit</string>
 		<string>alook</string>
 		<string>dgis</string>
+		<string>hamroh</string>
 		<string>microsoft-edge-http</string>
 		<string>brave</string>
 		<string>onionhttp</string>

--- a/Telegram/Telegram-iOS/InfoBazel.plist
+++ b/Telegram/Telegram-iOS/InfoBazel.plist
@@ -93,6 +93,7 @@
 		<string>moovit</string>
 		<string>alook</string>
 		<string>dgis</string>
+		<string>hamroh</string>
 		<string>microsoft-edge-http</string>
 		<string>brave</string>
 		<string>onionhttp</string>

--- a/submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift
+++ b/submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift
@@ -306,6 +306,10 @@ private func allOpenInOptions(context: AccountContext, item: OpenInItem) -> [Ope
                 }
             }))
             
+            options.append(OpenInOption(identifier: "hamroh", application: .other(title: "Hamroh", identifier: 6745878978, scheme: "hamroh", store: "uz"), action: {
+                return .openUrl(url: "hamroh://location?lat=\(lat)&lon=\(lon)")
+            }))
+            
             options.append(OpenInOption(identifier: "moovit", application: .other(title: "Moovit", identifier: 498477945, scheme: "moovit", store: nil), action: {
                 if let _ = directions {
                     let destName: String


### PR DESCRIPTION
This PR adds **Hamroh** — a widely used navigation/super-app in Uzbekistan (traffic fines, vehicles, payments, and turn-by-turn navigation powered by 2GIS) — to the location "Open in…" options, following #2227 (CASVA) and the existing 2GIS/Yandex integrations.

When a user opens or shares a location, Hamroh will appear in the list and open a route to the destination.

**App details**
- Name: Hamroh
- App Store ID: 6745878978 (https://apps.apple.com/app/id6745878978)
- Bundle ID: uz.mobilex.hamroh
- URL scheme: `hamroh`
- Location URL format: `hamroh://location?lat={lat}&lon={lon}`

**Changes** (same pattern as #2227)
- `submodules/OpenInExternalAppUI/Sources/OpenInOptions.swift` — register the Hamroh option
- `Telegram/Telegram-iOS/Info.plist`, `Telegram/Telegram-iOS/InfoBazel.plist`, `Telegram/BUILD` — whitelist the `hamroh` scheme in `LSApplicationQueriesSchemes`

The app already handles `hamroh://location?lat=..&lon=..` and opens the built-in navigator with a route to the given coordinates.