### PR TITLE
Watch: pre-cache favorite and frequently used stickers

### DIFF
--- a/Telegram/Watch/Bridge/TGBridgeStickersSignals.h
+++ b/Telegram/Watch/Bridge/TGBridgeStickersSignals.h
@@ -7,4 +7,6 @@
 
 + (NSURL *)stickerPacksURL;
 
++ (void)prefetchRecentStickersWithLimit:(NSUInteger)limit;
+
 @end

--- a/Telegram/Watch/Bridge/TGBridgeStickersSignals.m
+++ b/Telegram/Watch/Bridge/TGBridgeStickersSignals.m
@@ -4,6 +4,8 @@
 
 #import "TGBridgeStickerPack.h"
 #import "TGBridgeClient.h"
+#import "TGBridgeMediaSignals.h"
+#import "TGWatchCommon.h"
 
 @implementation TGBridgeStickersSignals
 
@@ -16,18 +18,17 @@ static NSArray *cachedStickers = nil;
 
 + (SSignal *)recentStickersWithLimit:(NSUInteger)limit
 {
-    return [[TGBridgeClient instance] requestSignalWithSubscription:[[TGBridgeRecentStickersSubscription alloc] initWithLimit:limit]];
-//    return [[self cachedRecentStickers] mapToSignal:^SSignal *(NSArray *stickers) {
-//        SSignal *remote = [[TGBridgeClient instance] requestSignalWithSubscription:[[TGBridgeRecentStickersSubscription alloc] initWithLimit:limit]];
-//        remote = [remote onNext:^(NSArray *stickers) {
-//            cachedStickers = stickers;
-//        }];
-//        if (stickers != nil) {
-//            return [[SSignal single:stickers] then:remote];
-//        } else {
-//            return remote;
-//        }
-//    }];
+    return [[self cachedRecentStickers] mapToSignal:^SSignal *(NSArray *stickers) {
+        SSignal *remote = [[TGBridgeClient instance] requestSignalWithSubscription:[[TGBridgeRecentStickersSubscription alloc] initWithLimit:limit]];
+        remote = [remote onNext:^(NSArray *stickers) {
+            cachedStickers = stickers;
+        }];
+        if (stickers != nil) {
+            return [[SSignal single:stickers] then:remote];
+        } else {
+            return remote;
+        }
+    }];
 }
 
 + (SSignal *)stickerPacks
@@ -45,6 +46,19 @@ static NSArray *cachedStickers = nil;
         stickerPacksURL = [[NSURL alloc] initFileURLWithPath:[documentsPath stringByAppendingPathComponent:@"stickers.data"]];
     });
     return stickerPacksURL;
+}
+
++ (void)prefetchRecentStickersWithLimit:(NSUInteger)limit
+{
+    [[[self recentStickersWithLimit:limit] deliverOn:[SQueue mainQueue]] startWithNext:^(NSArray *stickers)
+    {
+        for (TGBridgeDocumentMediaAttachment *sticker in stickers)
+        {
+            CGSize stickerSize = TGWatchStickerSizeForScreen(TGWatchScreenType());
+            NSString *imageUrl = [NSString stringWithFormat:@"sticker_%lld_%dx%d_0", sticker.documentId, (int)stickerSize.width, (int)stickerSize.height];
+            [[[TGBridgeMediaSignals stickerWithDocumentId:sticker.documentId packId:sticker.stickerPackId accessHash:sticker.stickerPackAccessHash type:TGMediaStickerImageTypeNormal] deliverOn:[SQueue mainQueue]] startWithNext:^(id next) {}];
+        }
+    }];
 }
 
 @end

--- a/Telegram/Watch/Extension/TGStickersController.m
+++ b/Telegram/Watch/Extension/TGStickersController.m
@@ -117,6 +117,7 @@ NSString *const TGStickersControllerIdentifier = @"TGStickersController";
                 updateInteface(initial, currentStickerModels, true);
             }
         }]];
+        [TGBridgeStickersSignals prefetchRecentStickersWithLimit:24];
     }
     else
     {

--- a/Telegram/WatchApp/tgwatch Watch App/Stickers/StickerPicker.swift
+++ b/Telegram/WatchApp/tgwatch Watch App/Stickers/StickerPicker.swift
@@ -19,6 +19,14 @@ struct PickerSticker: Identifiable, Equatable, Hashable {
     let emoji: String
     let width: Int
     let height: Int
+
+    var renderFileId: Int? {
+        switch render {
+        case .raster(let id, _): return id
+        case .lottie(let id): return id
+        case .none: return nil
+        }
+    }
 }
 
 /// How to produce a static grid-tile image for a sticker.

--- a/Telegram/WatchApp/tgwatch Watch App/Stickers/StickerPickerStore.swift
+++ b/Telegram/WatchApp/tgwatch Watch App/Stickers/StickerPickerStore.swift
@@ -21,6 +21,7 @@ final class StickerPickerStore {
     private let logger = Logger(subsystem: "org.telegram.TelegramWatch", category: "stickerpicker")
     private var files: [Int: File] = [:]
     private var trackedFileIds: Set<Int> = []
+    private var pinnedFileIds: Set<Int> = []
     private var setStickers: [Int64: [PickerSticker]] = [:]
 
     init(loader: StickerPickerLoader) {
@@ -52,6 +53,7 @@ final class StickerPickerStore {
     }
 
     func cancelFileDownload(fileId: Int) {
+        guard !pinnedFileIds.contains(fileId) else { return }
         trackedFileIds.remove(fileId)
         logger.info("cancelFileDownload fileId=\(fileId, privacy: .public)")
         Task { [logger, loader] in
@@ -59,6 +61,33 @@ final class StickerPickerStore {
                 try await loader.cancelDownloadFile(fileId: fileId)
             } catch {
                 logger.warning("cancelDownloadFile fileId=\(fileId, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Pre-downloads favorite and recent stickers with high priority so they are
+    /// cached on disk before the user scrolls to them. Pinned file IDs are
+    /// protected from cancellation by `cancelFileDownload`.
+    func prefetchStickers() {
+        let all = favorites + recents
+        var renderIds = Set<Int>()
+        for sticker in all {
+            if let id = sticker.renderFileId {
+                renderIds.insert(id)
+            }
+        }
+        guard !renderIds.isEmpty else { return }
+        let newIds = renderIds.subtracting(trackedFileIds)
+        pinnedFileIds.formUnion(newIds)
+        trackedFileIds.formUnion(newIds)
+        logger.info("prefetchStickers: pinning \(newIds.count, privacy: .public) sticker render files")
+        for id in newIds {
+            Task { [logger, loader] in
+                do {
+                    _ = try await loader.downloadFile(fileId: id, priority: 4)
+                } catch {
+                    logger.warning("prefetch fileId=\(id, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+                }
             }
         }
     }

--- a/Telegram/WatchApp/tgwatch Watch App/Stickers/StickerPickerView.swift
+++ b/Telegram/WatchApp/tgwatch Watch App/Stickers/StickerPickerView.swift
@@ -30,6 +30,7 @@ struct StickerPickerView: View {
             .task {
                 client.setActiveStickerPicker(store)
                 await store.load()
+                store.prefetchStickers()
             }
             .onDisappear { client.setActiveStickerPicker(nil) }
     }


### PR DESCRIPTION
Stickers were downloaded on-demand only when visible and cancelled when scrolled off-screen, causing them to re-download every time the picker opened. This adds:

- StickerPickerStore.prefetchStickers() that pre-downloads all favorite and recent sticker render files at priority 4 (highest)
- Pinned file IDs protected from cancellation by cancelFileDownload()
- TGBridgeStickersSignals.prefetchRecentStickersWithLimit: that triggers the full image download pipeline for recent stickers through TGFileCache
- Re-enabled the in-memory caching layer for recent stickers in the legacy WatchKit extension
- TGStickersController now calls prefetch after loading the sticker list