### PR TITLE
Make TDLib builds more hermetic

### DIFF
--- a/third-party/td/build-td-bazel.sh
+++ b/third-party/td/build-td-bazel.sh
@@ -16,13 +16,14 @@ options="$options -DOPENSSL_CRYPTO_LIBRARY=${openssl_crypto_library}"
 options="$options -DOPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/src/include"
 options="$options -DCMAKE_BUILD_TYPE=Release"
 options="$options -DIOS_DEPLOYMENT_TARGET=13.0"
+options="$options -DCCACHE_FOUND=0"
 
 cd "$BUILD_DIR"
 
 # Generate source files
 mkdir native-build
 cd native-build
-cmake -DTD_GENERATE_SOURCE_FILES=ON ../td
+cmake -DCCACHE_FOUND=0 -DTD_GENERATE_SOURCE_FILES=ON ../td
 cmake --build . -- -j$(sysctl -n hw.ncpu)
 cd ..
 


### PR DESCRIPTION
When `ccache` is installed in system, TDLib may report `CCACHE_FOUND=1` during configuration and generate ccache-dependent compile commands. However, Bazel will fail to execute them, since it tries to be hermetic and there is no `ccache` in `$PATH`.

<details><summary>Error log</summary>

```
[3,184 / 5,953] Compiling Swift module //submodules/TelegramApi:TelegramApi; 101s worker ... (6 actions running)
ERROR: /Users/admin/.cache/act/ca1cbef3abe92f84/hostexecutor/Telegram-iOS/third-party/td/BUILD:23:8: Executing genrule //third-party/td:td_build failed: (Exit 2): bash failed: error executing Genrule command (from target //third-party/td:td_build) 
  (cd /private/var/tmp/_bazel_admin/28e24203993477b4b129fe9b797f560f/execroot/_main && \
  exec env - \
    PATH=/usr/bin:/bin:/usr/sbin:/sbin \
    ZERO_AR_DATE=1 \
  /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; 
    set -ex
    if [ "ios_sim_arm64" == "ios_arm64" ]; then
        BUILD_ARCH="arm64"
... TRUNCATED ...
+ cd /private/var/tmp/_bazel_admin/28e24203993477b4b129fe9b797f560f/execroot/_main/bazel-out/ios_sim_arm64-opt-ios-sim_arm64-min13.0-ST-28e2ff30e5be/bin/third-party/td/build_sim_arm64
+ mkdir native-build
+ cd native-build
+ cmake -DTD_GENERATE_SOURCE_FILES=ON ../td
++ sysctl -n hw.ncpu
+ cmake --build . -- -j6
/bin/sh: ccache: command not found
/bin/sh: ccache: command not found
make[2]: *** [tdutils/generate/CMakeFiles/generate_mime_types_gperf.dir/generate_mime_types_gperf.cpp.o] Error 127
```

</details> 


This PR makes TDLib builds a little more hermetic. Disabling `ccache` should not be a problem for day to day development, Bazel will reuse outputs if TDLib is unchanged.

I've first noticed it on my system, but was able to quickly reproduce in a [similar VM container](https://github.com/cirruslabs/macos-image-templates), simply doing `brew install ccache`.
This may become a more frequent scenario when TDLib will be updated, since it will be able to [correctly report](https://github.com/tdlib/td/pull/3668) tools availability, including ccache.