### PR TITLE
Fix mention detection inside email addresses

### DIFF
--- a/submodules/TextFormat/Sources/GenerateTextEntities.swift
+++ b/submodules/TextFormat/Sources/GenerateTextEntities.swift
@@ -35,6 +35,11 @@ private let identifierDelimiterSet: CharacterSet = {
     set.insert("/")
     return set
 }()
+private let mentionDelimiterSet: CharacterSet = {
+    var set = CharacterSet.whitespacesAndNewlines
+    set.insert("(")
+    return set
+}()
 private let externalIdentifierDelimiterSet: CharacterSet = {
     var set = identifierDelimiterSet
     set.remove(".")
@@ -329,14 +334,20 @@ public func generateTextEntities(_ text: String, enabledTypes: EnabledEntityType
                 }
             } else if scalar == "@" {
                 notFound = false
+                let isMentionBoundary: Bool
+                if let previousScalar = previousScalar {
+                    isMentionBoundary = mentionDelimiterSet.contains(previousScalar)
+                } else {
+                    isMentionBoundary = true
+                }
                 if let (type, range) = currentEntity {
                     if case .command = type {
                         currentEntity = (type, range.lowerBound ..< utf16.index(after: index))
                     } else {
                         commitEntity(utf16, type, range, enabledTypes, &entities)
-                        currentEntity = (.mention, index ..< index)
+                        currentEntity = isMentionBoundary ? (.mention, index ..< index) : nil
                     }
-                } else {
+                } else if isMentionBoundary {
                     currentEntity = (.mention, index ..< index)
                 }
             } else if scalar == "#" {


### PR DESCRIPTION
 Telegram for iOS incorrectly detects `@username` mentions inside email addresses in profile bios.
 
 For example, in `me@example.com`, the `@example` substring is rendered as a clickable username mention.
 
 Other Telegram clients do not create a mention for the same input:

Telegram iOS
<img width="283" height="67" alt="image" src="https://github.com/user-attachments/assets/baa7384d-511e-4072-a7f9-f059fbc2da71" />


Telegram Android
<img width="291" height="63" alt="image" src="https://github.com/user-attachments/assets/d6d4474a-b4d6-44a5-b27f-388693bae039" />


Telegram Desktop
<img width="285" height="83" alt="image" src="https://github.com/user-attachments/assets/1ad5c9c5-4bee-481c-9f46-6c5d04607413" />

Telegram Web K
<img width="321" height="70" alt="image" src="https://github.com/user-attachments/assets/729efce2-5261-4974-b9af-e3f44c611ca4" />

Telegram Web A
<img width="350" height="75" alt="image" src="https://github.com/user-attachments/assets/fed75f82-324b-424e-9b6a-dc50c762dbf3" />


This PR applies same mention boundary mechanism as in android client.

Direct comparison before/after of this PR:

<img width="393" height="852" alt="image" src="https://github.com/user-attachments/assets/07738bb0-c8a4-403d-aec5-b38b8d88cf5a" />

<img width="391" height="851" alt="image" src="https://github.com/user-attachments/assets/4632573a-a498-4a52-a0a4-3239f639a554" />