### PR TITLE
Fix calls from Phone recents opening without starting

### DIFF
--- a/submodules/TelegramUI/Sources/AppDelegate.swift
+++ b/submodules/TelegramUI/Sources/AppDelegate.swift
@@ -2545,6 +2545,18 @@ private func extractAccountManagerState(records: AccountRecordsView<TelegramAcco
     
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if #available(iOS 10.0, *) {
+            let startCallHandlePrefix = "TGCA"
+            if userActivity.activityType == NSStringFromClass(INStartCallIntent.self),
+               let handle = userActivity.userInfo?["handle"] as? String,
+               handle.hasPrefix(startCallHandlePrefix),
+               let peerIdValue = Int64(handle.dropFirst(startCallHandlePrefix.count)) {
+                let peerId = PeerId(peerIdValue)
+                if peerId.namespace == Namespaces.Peer.CloudUser {
+                    self.startCallWhenReady(accountId: nil, peerId: peerId, isVideo: false)
+                    return true
+                }
+            }
+
             var startCallContacts: [INPerson]?
             var isVideo = false
             if let startCallIntent = userActivity.interaction?.intent as? SupportedStartCallIntent {


### PR DESCRIPTION
## Summary

- handle the `NSUserActivity` payload produced by the Siri Intents `INStartCallIntent` handler
- validate the activity type, `TGCA` prefix, and cloud-user peer namespace before starting the call
- preserve the existing `interaction?.intent` contact-resolution path

## Problem

When a user taps a Telegram call in Phone > Recents, the Siri Intents extension resolves the contact and returns `.continueInApp` with `userInfo["handle"] = "TGCA<peerId>"`.

`AppDelegate.application(_:continue:restorationHandler:)` currently only inspects `userActivity.interaction?.intent`. When the continuation activity contains the serialized `TGCA` handle but no interaction, Telegram opens and returns `true` without starting a call.

This change consumes that existing payload and forwards the decoded peer to `startCallWhenReady`, which reaches the normal call flow.

## Validation

- `git diff --check`
- verified the producer and consumer use the same `INStartCallIntent` activity type and `TGCA<peerId>` format
- verified malformed handles and non-cloud-user peer identifiers do not use the new path

Not run on an iPhone because a macOS/Xcode signing environment was not available.
