### PR TITLE
Loop emoji statuses forever in voice chat participant list

### DIFF
--- a/submodules/TelegramCallsUI/Sources/VoiceChatParticipantItem.swift
+++ b/submodules/TelegramCallsUI/Sources/VoiceChatParticipantItem.swift
@@ -841,7 +841,7 @@ class VoiceChatParticipantItemNode: ItemListRevealOptionsItemNode {
             } else if item.peer.isFake {
                 credibilityIcon = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_FakeAccount.uppercased())
             } else if let emojiStatus = item.peer.emojiStatus {
-                credibilityIcon = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: item.presentationData.theme.list.mediaPlaceholderColor, themeColor: item.presentationData.theme.list.itemAccentColor, loopMode: .count(2))
+                credibilityIcon = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: item.presentationData.theme.list.mediaPlaceholderColor, themeColor: item.presentationData.theme.list.itemAccentColor, loopMode: .forever)
             } else if item.peer.isVerified {
                 credibilityIcon = .verified(fillColor: item.presentationData.theme.list.itemCheckColors.fillColor, foregroundColor: item.presentationData.theme.list.itemCheckColors.foregroundColor, sizeType: .compact)
             } else if item.peer.isPremium && !premiumConfiguration.isPremiumDisabled {


### PR DESCRIPTION
## Summary
- Voice chat participant emoji statuses use `EmojiStatusComponent.LoopMode.count(2)`, so custom video emoji freeze mid-call while gift overlays keep animating.
- Switch the credibility emoji status icon in `VoiceChatParticipantItem` to `.forever`.

## Test plan
- [ ] Join a voice chat with a Premium emoji status set (video custom emoji preferred)
- [ ] Confirm the status next to the name keeps looping for the whole call
- [ ] Confirm chat-list / profile emoji statuses still use limited loops where intended
- [ ] Confirm verified / premium-star / scam badges still render

Related: DrKLO/Telegram#2049

Made with [Cursor](https://cursor.com)